### PR TITLE
Fix use of Tpetra

### DIFF
--- a/include/LinearSolver.h
+++ b/include/LinearSolver.h
@@ -33,8 +33,7 @@ typedef double                                                        Scalar;
 typedef long                                                          GlobalOrdinal;
 typedef int                                                           LocalOrdinal;
 typedef Tpetra::DefaultPlatform::DefaultPlatformType                  Platform;
-typedef Kokkos::SerialNode                                            Node;
-typedef Kokkos::DefaultKernels<Scalar,LocalOrdinal,Node>::SparseOps   LocalMatOps;
+typedef KokkosClassic::DefaultNode::DefaultNodeType                        Node;
 typedef Teuchos::ScalarTraits<Scalar> STS;
 
 // MueLu main header: include most common header files in one line

--- a/include/LinearSolverTypes.h
+++ b/include/LinearSolverTypes.h
@@ -44,10 +44,10 @@ class Map;
 template <typename LocalOrdinal, typename GlobalOrdinal, typename Node >
 class Export;
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node, bool classic>
 class MultiVector;
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node, bool classic>
 class Vector;
 
 template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>

--- a/include/LinearSolverTypes.h
+++ b/include/LinearSolverTypes.h
@@ -99,11 +99,10 @@ typedef long   GlobalOrdinal; // MUST be signed
 typedef int    LocalOrdinal;  // MUST be signed
 typedef double Scalar;
 
-typedef Kokkos::SerialNode                                                 Node;
+typedef KokkosClassic::DefaultNode::DefaultNodeType                        Node;
 typedef Teuchos::MpiComm<int>                                              Comm;
 typedef Tpetra::Export< LocalOrdinal, GlobalOrdinal, Node >                Export;
 typedef Tpetra::Import< LocalOrdinal, GlobalOrdinal, Node >                Import;
-typedef Kokkos::DefaultKernels<void,LocalOrdinal,Node>::SparseOps          LocalMatOps;
 typedef Tpetra::CrsGraph< LocalOrdinal, GlobalOrdinal, Node>               Graph;
 typedef Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node>                       Map;
 typedef Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>        MultiVector;


### PR DESCRIPTION
These two commits will (i) make Nalu use the default node type as configured in the Trilinos build
(ii) fix an issue with a forward declaration of Tpetra MultiVector and Tpetra Vector.