### PR TITLE
Add arbitrary order polynomial promotion capability

### DIFF
--- a/include/MaterialPropertys.h
+++ b/include/MaterialPropertys.h
@@ -54,9 +54,12 @@ public:
   Realm &realm_;
   MaterialPropertyVector materialPropertyVector_;
   std::string propertyTableName_;
+  std::string promotionTag_;
 
   // vectors and maps required to manage full set of options
   std::vector<std::string> targetNames_;
+  std::vector<std::string> baseTargetNames_;
+  std::vector<std::string> promotedTargetNames_;
   std::map<std::string, double> universalConstantMap_;
   std::map<PropertyIdentifier, MaterialPropertyData*> propertyDataMap_;
   std::map<std::string, ReferencePropertyData*> referencePropertyDataMap_; /* defines overall species ordering */

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -25,12 +25,14 @@
 
 // standard c++
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 #include <stdint.h>
 
 namespace stk {
 namespace mesh {
+struct Entity;
 class Part;
 }
 namespace io {
@@ -71,6 +73,9 @@ class MasterElement;
 class PropertyEvaluator;
 class HDF5FilePtr;
 class Transfer;
+class ElementDescription;
+class PromoteElement;
+class PromotedElementIO;
 
 class Realm {
  public:
@@ -473,6 +478,31 @@ class Realm {
 
   // empty part vector should it be required
   stk::mesh::PartVector emptyPartVector_;
+
+  // Part holding added nodes
+  stk::mesh::PartVector basePartVector_;
+  stk::mesh::PartVector promotedPartVector_;
+
+  // Part holding added nodes BC
+  stk::mesh::PartVector bcPromotedPartVector_;
+
+  // element promotion tools
+  bool doPromotion_;
+  unsigned promotionOrder_;
+  double timerPromoteMesh_;
+  std::unique_ptr<ElementDescription> elem_;
+  std::unique_ptr<PromoteElement> promotion_;
+  std::unique_ptr<PromotedElementIO> promotionIO_;
+  void promote_elements();
+  void side_node_ordinals_all(
+    const stk::topology& theElemTopo,
+    unsigned face_ordinal,
+    std::vector<int>& face_node_ordinal_vec) const;
+  stk::mesh::Entity const* begin_nodes_all(stk::mesh::Entity elem) const;
+  stk::mesh::Entity const* begin_nodes_all(const stk::mesh::Bucket& b, stk::mesh::EntityId offset) const;
+  unsigned num_nodes_all(const stk::mesh::Bucket& bucket,
+    stk::mesh::EntityId id) const;
+  unsigned num_nodes_all(stk::mesh::Entity elem) const;
 
   std::vector<AuxFunctionAlgorithm *> bcDataAlg_;
 

--- a/include/element_promotion/ElementDescription.h
+++ b/include/element_promotion/ElementDescription.h
@@ -1,0 +1,133 @@
+#ifndef ElementDescription_h
+#define ElementDescription_h
+
+#include <element_promotion/LagrangeBasis.h>
+#include <element_promotion/TensorProductQuadratureRule.h>
+
+#include <stddef.h>
+#include <map>
+#include <memory>
+#include <vector>
+
+namespace sierra {
+namespace nalu {
+
+typedef std::map<std::vector<size_t>, std::vector<size_t>> AddedConnectivityOrdinalMap;
+typedef std::map<std::vector<size_t>, std::vector<std::vector<double>>> AddedNodeLocationsMap;
+typedef std::vector<std::vector<size_t>> SubElementConnectivity;
+
+struct ElementDescription
+{
+public:
+  static std::unique_ptr<ElementDescription> create(int dimension, int order);
+  virtual ~ElementDescription() = default;
+
+  inline int tensor_product_node_map(int i, int j, int k) const
+  {
+    return nodeMap[i+nodes1D*(j+nodes1D*k)];
+  }
+
+  inline int tensor_product_node_map(int i, int j) const
+  {
+    return nodeMap[i+nodes1D*j];
+  }
+
+  inline int tensor_product_node_map_bc(int i, int j) const
+  {
+    return nodeMapBC[i+nodes1D*j];
+  }
+
+  inline int tensor_product_node_map(int i) const
+  {
+    return nodeMapBC[i];
+  }
+
+  inline double gauss_point_location(
+    int nodeOrdinal,
+    int gaussPointOrdinal) const
+  {
+    return quadrature->gauss_point_location(nodeOrdinal,gaussPointOrdinal);
+  }
+
+  inline double tensor_product_weight(
+    int s1Node, int s2Node, int s3Node,
+    int s1Ip, int s2Ip, int s3Ip) const
+  {
+    return quadrature->tensor_product_weight(s1Node,s2Node,s3Node,s1Ip,s2Ip,s3Ip);
+  }
+
+  inline double tensor_product_weight(
+    int s1Node, int s2Node,
+    int s1Ip, int s2Ip) const
+  {
+    return quadrature->tensor_product_weight(s1Node,s2Node, s1Ip,s2Ip);
+  }
+
+  inline double tensor_product_weight(int s1Node, int s1Ip) const
+  {
+    return quadrature->tensor_product_weight(s1Node, s1Ip);
+  }
+
+  inline std::vector<double>
+  eval_basis_weights(const std::vector<double>& intgLoc) const
+  {
+     return basis->eval_basis_weights(intgLoc);
+  }
+
+  inline std::vector<double>
+  eval_deriv_weights(const std::vector<double>& intgLoc) const
+  {
+    return basis->eval_deriv_weights(intgLoc);
+  }
+
+  std::vector<double> scsLoc;
+  std::vector<double> nodeLocs;
+
+  size_t dimension;
+  size_t nodes1D;
+  size_t nodesPerElement;
+  AddedConnectivityOrdinalMap addedConnectivities;
+  AddedConnectivityOrdinalMap edgeNodeConnectivities;
+  AddedConnectivityOrdinalMap faceNodeConnectivities;
+  AddedConnectivityOrdinalMap volumeNodeConnectivities;
+  AddedNodeLocationsMap locationsForNewNodes;
+  SubElementConnectivity subElementConnectivity;
+
+  bool useGLLGLL;
+  unsigned polyOrder;
+  unsigned numQuad;
+  std::unique_ptr<TensorProductQuadratureRule> quadrature;
+  std::unique_ptr<LagrangeBasis> basis;
+  std::unique_ptr<LagrangeBasis> basisBoundary;
+  std::vector<unsigned> nodeMap;
+  std::vector<unsigned> nodeMapBC;
+  std::vector<std::vector<unsigned>> inverseNodeMap;
+  std::vector<std::vector<unsigned>> inverseNodeMapBC;
+  std::vector<std::vector<size_t>> faceNodeMap;
+  std::vector<std::vector<size_t>> sideOrdinalMap;
+protected:
+  ElementDescription() = default;
+};
+
+struct QuadMElementDescription: public ElementDescription
+{
+public:
+  QuadMElementDescription(std::vector<double> in_nodeLocs, std::vector<double> in_scsLoc);
+private:
+  void set_node_connectivity();
+  void set_subelement_connectivity();
+};
+
+struct HexMElementDescription: public ElementDescription
+{
+public:
+  HexMElementDescription(std::vector<double> in_nodeLocs, std::vector<double> in_scsLoc);
+private:
+  void set_node_connectivity();
+  void set_subelement_connectivity();
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/element_promotion/FaceOperations.h
+++ b/include/element_promotion/FaceOperations.h
@@ -1,0 +1,184 @@
+#ifndef FaceOperations_h
+#define FaceOperations_h
+
+#include <stddef.h>
+#include <vector>
+#include <stk_util/environment/ReportHandler.hpp>
+
+namespace sierra {
+namespace nalu {
+
+  template<class T>
+  constexpr T ipow(const T base, unsigned const exponent)
+  {
+    return (exponent == 0) ? 1 : (base * ipow(base, exponent-1));
+  }
+
+  template<typename T> bool
+  parents_are_reversed(
+    const std::vector<T>& test,
+    const std::vector<T>& gold)
+  {
+    const unsigned numParents = gold.size();
+    ThrowAssert(test.size() == numParents);
+
+    bool parentAreFlipped = true;
+    for (unsigned j = 0; j < numParents; ++j) {
+      if (gold[j] != test[numParents-1-j]) {
+        return false;
+      }
+    }
+    return parentAreFlipped;
+  }
+
+  template<typename T> std::vector<T>
+  flip_x(
+    const std::vector<T>& childOrdinals,
+    unsigned size1D)
+  {
+    ThrowAssert(childOrdinals.size() == size1D*size1D);
+
+    std::vector<T> reorderedOrdinals(childOrdinals.size());
+    for (unsigned j = 0; j < size1D; ++j) {
+      for (unsigned i = 0; i < size1D; ++i) {
+        int ir = size1D-i-1;
+        reorderedOrdinals[i+size1D*j] = childOrdinals[ir+size1D*j];
+      }
+    }
+    return reorderedOrdinals;
+  }
+
+  template<typename T> bool
+  parents_are_flipped_x(
+    const std::vector<T>& test,
+    const std::vector<T>& gold,
+    unsigned size1D)
+  {
+    ThrowAssert(test.size() == gold.size());
+    if (test.size() != size1D*size1D) {
+      return false;
+    }
+
+    bool parentAreFlipped = true;
+    for (unsigned j = 0; j < size1D; ++j) {
+      for (unsigned i = 0; i < size1D; ++i) {
+        int ir = size1D-i-1;
+        if (gold[i+size1D*j] != test[ir+size1D*j]) {
+          return false;
+        }
+      }
+    }
+    return parentAreFlipped;
+  }
+
+  template<typename T> std::vector<T>
+  flip_y(
+    const std::vector<T>& childOrdinals,
+    unsigned size1D)
+  {
+    ThrowAssert(childOrdinals.size() == size1D*size1D);
+
+    std::vector<T> reorderedOrdinals(childOrdinals.size());
+    for (unsigned j = 0; j < size1D; ++j) {
+      int jr = size1D-j-1;
+      for (unsigned i = 0; i < size1D; ++i) {
+        reorderedOrdinals[i+size1D*j] = childOrdinals[i+size1D*jr];
+      }
+    }
+    return reorderedOrdinals;
+  }
+
+  template<typename T> bool
+  parents_are_flipped_y(
+    const std::vector<T>& test,
+    const std::vector<T>& gold,
+    unsigned size1D)
+  {
+    ThrowAssert(test.size() == gold.size());
+    if (test.size() != size1D*size1D) {
+      return false;
+    }
+    bool parentAreFlipped = true;
+    for (unsigned j = 0; j < size1D; ++j) {
+      int jr = size1D-j-1;
+      for (unsigned i = 0; i < size1D; ++i) {
+        if (gold[i+size1D*j] != test[i+size1D*jr]) {
+          return false;
+        }
+      }
+    }
+    return parentAreFlipped;
+  }
+
+  template<typename T> bool
+  should_transpose(
+    const std::vector<T>& test,
+    const std::vector<T>& gold)
+  {
+    ThrowAssert(test.size() == gold.size());
+    if (test.size() != 4) {
+      return false;
+    }
+
+    //check if off-diagonal nodes ((1,0)->1 and (0,1)->3) are reversed
+    // if so, transpose the ordinals
+    return (test[1] == gold[3] && test[3] == gold[1]);
+  }
+
+
+  template<typename T> std::vector<T>
+  transpose_ordinals(
+    const std::vector<T>& childOrdinals,
+    unsigned size1D)
+  {
+    ThrowAssert(childOrdinals.size() == size1D*size1D);
+
+    std::vector<T> reorderedOrdinals(childOrdinals.size());
+    for (unsigned j = 0; j < size1D; ++j) {
+      for (unsigned i = 0; i < size1D; ++i) {
+        reorderedOrdinals[i+size1D*j] = childOrdinals[j+size1D*i];
+      }
+    }
+    return reorderedOrdinals;
+  }
+
+  template<typename T> bool
+  should_invert(
+    const std::vector<T>& test,
+    const std::vector<T>& gold)
+  {
+    ThrowAssert(test.size() == gold.size());
+    if (test.size() != 4) {
+      return false;
+    }
+
+    //check if diagonal nodes ((0,0)->0 and (1,1)->2) are reversed
+    // if so, transpose-reverse the ordinals
+    return (test[0] == gold[2]
+         && test[1] == gold[1]
+         && test[2] == gold[0]
+         && test[3] == gold[3] );
+  }
+
+  template<typename T> std::vector<T>
+  invert_ordinals_yx(
+    const std::vector<T>& childOrdinals,
+    unsigned size1D)
+  {
+    ThrowAssert(childOrdinals.size() == size1D*size1D);
+
+    std::vector<T> reorderedOrdinals(childOrdinals.size());
+    for (unsigned j = 0; j < size1D; ++j) {
+      int jr = size1D-j-1;
+      for (unsigned i = 0; i < size1D; ++i) {
+        int ir = size1D-i-1;
+        reorderedOrdinals[i+size1D*j] = childOrdinals[jr+size1D*ir];
+      }
+    }
+    return reorderedOrdinals;
+  }
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/element_promotion/LagrangeBasis.h
+++ b/include/element_promotion/LagrangeBasis.h
@@ -1,0 +1,54 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+#ifndef TensorProductBasis_h
+#define TensorProductBasis_h
+
+#include <vector>
+
+namespace sierra{
+namespace nalu{
+
+class LagrangeBasis
+{
+public:
+  LagrangeBasis(
+    std::vector<std::vector<unsigned>>&  indicesMap,
+    const std::vector<double>& nodeLocs
+  );
+
+  virtual ~LagrangeBasis() {};
+
+  void set_lagrange_weights();
+
+  std::vector<double> eval_basis_weights(
+    const std::vector<double>& intgLoc) const;
+
+  std::vector<double> eval_deriv_weights(
+    const std::vector<double>& intgLoc) const;
+
+  double tensor_lagrange_derivative(
+    unsigned dimension,
+    const double* x,
+    const unsigned* nodes,
+    unsigned derivativeDirection
+  ) const;
+  double tensor_lagrange_interpolant(unsigned dimension, const double* x, const unsigned* nodes) const;
+  double lagrange_1D(double x, unsigned nodeNumber) const;
+  double lagrange_deriv_1D(double x, unsigned nodeNumber) const;
+
+  std::vector<std::vector<unsigned>> indicesMap_;
+  unsigned numNodes1D_;
+  std::vector<double> nodeLocs_;
+  const unsigned dimension_;
+  std::vector<double> lagrangeWeights_;
+};
+
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/element_promotion/MasterElementHO.h
+++ b/include/element_promotion/MasterElementHO.h
@@ -1,0 +1,305 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+#ifndef MasterElementHO_h
+#define MasterElementHO_h
+
+#include <master_element/MasterElement.h>
+#include <vector>
+#include <array>
+
+namespace sierra{
+namespace nalu{
+
+  struct ContourData {
+    Jacobian::Direction direction;
+    double weight;
+  };
+
+// 2D Quad 16 subcontrol volume
+struct ElementDescription;
+
+class HigherOrderHexSCV : public MasterElement
+{
+public:
+  HigherOrderHexSCV(const ElementDescription& elem);
+  virtual ~HigherOrderHexSCV() {}
+
+  void shape_fcn(double *shpfc) final;
+  const int * ipNodeMap(int ordinal = 0) final;
+
+  void determinant(
+    const int nelem,
+    const double *coords,
+    double *volume,
+    double * error ) final;
+
+  const ElementDescription& elem_;
+  std::vector<double> ipWeight_;
+  std::vector<double> shapeFunctions_;
+  std::vector<double> shapeDerivs_;
+
+private:
+  void set_interior_info();
+
+  double jacobian_determinant(
+    const double *elemNodalCoords,
+    const double *shapeDerivs ) const;
+};
+
+// 3D Hex 27 subcontrol surface
+class HigherOrderHexSCS : public MasterElement
+{
+public:
+  HigherOrderHexSCS(const ElementDescription& elem);
+  virtual ~HigherOrderHexSCS() {}
+
+  void shape_fcn(double *shpfc) final;
+
+  void determinant(
+    const int nelem,
+    const double *coords,
+    double *areav,
+    double * error ) final;
+
+  void grad_op(
+    const int nelem,
+    const double *coords,
+    double *gradop,
+    double *deriv,
+    double *det_j,
+    double * error ) final;
+
+  void face_grad_op(
+    const int nelem,
+    const int face_ordinal,
+    const double *coords,
+    double *gradop,
+    double *det_j,
+    double * error ) final;
+
+  void gij(
+    const double *coords,
+    double *gupperij,
+    double *glowerij,
+    double *deriv) final;
+
+  const int * adjacentNodes() final;
+
+  const int * ipNodeMap(int ordinal = 0) final;
+
+  int opposingNodes(
+    const int ordinal, const int node) final;
+
+  int opposingFace(
+    const int ordinal, const int node) final;
+
+  const ElementDescription& elem_;
+  std::vector<double> shapeFunctions_;
+  std::vector<double> shapeDerivs_;
+  std::vector<double> expFaceShapeDerivs_;
+
+private:
+  void set_interior_info();
+  void set_boundary_info();
+
+  void area_vector(
+    const Jacobian::Direction direction,
+    const double *elemNodalCoords,
+    double *shapeDeriv,
+    std::array<double, 3>& areaVector ) const;
+
+  void gradient(
+    const double* elemNodalCoords,
+    const double* shapeDeriv,
+    double* grad,
+    double* det_j ) const;
+
+  std::vector<ContourData> ipInfo_;
+  int ipsPerFace_;
+};
+
+// 3D Quad 9
+class HigherOrderQuad3DSCS : public MasterElement
+{
+public:
+  HigherOrderQuad3DSCS(const ElementDescription& elem);
+  virtual ~HigherOrderQuad3DSCS() {}
+
+  void shape_fcn(double *shpfc) final;
+
+  const int * ipNodeMap(int ordinal = 0);
+
+  void determinant(
+    const int nelem,
+    const double *coords,
+    double *areav,
+    double * error );
+
+  const ElementDescription& elem_;
+  std::vector<double> shapeFunctions_;
+  std::vector<double> shapeDerivs_;
+
+private:
+  void set_interior_info();
+  void eval_shape_functions_at_ips();
+  void eval_shape_derivs_at_ips();
+
+  void area_vector(
+    const double *elemNodalCoords,
+    const double *shapeDeriv,
+    std::array<double,3>& areaVector) const;
+
+  void quad9_shape_fcn(
+    int numIntPoints,
+    const double *intgLoc,
+    double* shpfc
+  ) const;
+
+  void quad9_shape_deriv(
+    int numIntPoints,
+    const double *intgLoc,
+    double* deriv
+  ) const;
+
+  std::vector<double> ipWeight_;
+  int surfaceDimension_;
+};
+
+class HigherOrderQuad2DSCV : public MasterElement
+{
+public:
+  explicit HigherOrderQuad2DSCV(const ElementDescription& elem);
+  virtual ~HigherOrderQuad2DSCV() {}
+
+  void shape_fcn(double *shpfc) final;
+
+  const int * ipNodeMap(int ordinal = 0) final;
+
+  void determinant(
+    const int nelem,
+    const double *coords,
+    double *volume,
+    double * error ) final;
+
+  const ElementDescription& elem_;
+  std::vector<double> ipWeight_;
+  std::vector<double> shapeFunctions_;
+  std::vector<double> shapeDerivs_;
+private:
+  void set_interior_info();
+
+  double jacobian_determinant(
+    const double *elemNodalCoords,
+    const double *shapeDerivs ) const;
+};
+class HigherOrderQuad2DSCS : public MasterElement
+{
+public:
+  explicit HigherOrderQuad2DSCS(const ElementDescription& elem);
+  virtual ~HigherOrderQuad2DSCS() {}
+
+  void shape_fcn(double *shpfc) final;
+
+  void determinant(
+    const int nelem,
+    const double *coords,
+    double *areav,
+    double * error) final;
+
+  void grad_op(
+    const int nelem,
+    const double *coords,
+    double *gradop,
+    double *deriv,
+    double *det_j,
+    double * error) final;
+
+  void face_grad_op(
+    const int nelem,
+    const int face_ordinal,
+    const double *coords,
+    double *gradop,
+    double *det_j,
+    double * error) final;
+
+  void gij(
+    const double *coords,
+    double *gupperij,
+    double *glowerij,
+    double *deriv) final;
+
+  const int * adjacentNodes() final;
+
+  const int * ipNodeMap(int ordinal = 0) final;
+
+  int opposingNodes(
+    const int ordinal, const int node) final;
+
+  int opposingFace(
+    const int ordinal, const int node) final;
+
+  std::vector<double> shapeFunctions_;
+
+private:
+  void set_interior_info();
+  void set_boundary_info();
+
+  void area_vector(
+    const Jacobian::Direction direction,
+    const double* elemNodalCoords,
+    const double* shapeDeriv,
+    std::array<double,2>& areaVector) const;
+
+  void gradient(
+    const double* elemNodalCoords,
+    const double* shapeDeriv,
+    double* grad,
+    double* det_j) const;
+
+
+  const ElementDescription& elem_;
+  std::vector<ContourData> ipInfo_;
+  int ipsPerFace_;
+
+  std::vector<double> shapeDerivs_;
+  std::vector<double> expFaceShapeDerivs_;
+};
+
+class HigherOrderEdge2DSCS : public MasterElement
+{
+public:
+  explicit HigherOrderEdge2DSCS(const ElementDescription& elem);
+  virtual ~HigherOrderEdge2DSCS() {}
+
+  const int * ipNodeMap(int ordinal = 0) final;
+
+  void determinant(
+    const int nelem,
+    const double *coords,
+    double *areav,
+    double * error ) final;
+
+  void shape_fcn(
+    double *shpfc) final;
+
+  std::vector<double> shapeFunctions_;
+private:
+  void area_vector(
+    const double* elemNodalCoords,
+    const double* shapeDeriv,
+    std::array<double,2>&  areaVector) const;
+
+  const ElementDescription& elem_;
+  std::vector<double> ipWeight_;
+
+  std::vector<double> shapeDerivs_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/element_promotion/PromoteElement.h
+++ b/include/element_promotion/PromoteElement.h
@@ -1,0 +1,236 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level nalu      */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+#ifndef PromoteElement_h
+#define PromoteElement_h
+
+#include <element_promotion/ElementDescription.h>
+#include <element_promotion/FaceOperations.h>
+
+#include <stk_mesh/base/CoordinateSystems.hpp>
+
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/Selector.hpp>
+#include <stk_mesh/base/Types.hpp>
+
+#include <boost/functional/hash/hash.hpp>
+
+#include <array>
+#include <cstddef>
+#include <iosfwd>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace stk {
+namespace mesh {
+class Bucket;
+class BulkData;
+class MetaData;
+}  // namespace mesh
+}  // namespace stk
+
+// field types
+typedef stk::mesh::Field<double, stk::mesh::Cartesian>  VectorFieldType;
+
+namespace sierra {
+namespace nalu {
+
+  std::string promote_part_name(const std::string& base_name);
+  stk::mesh::Part* promoted_part(const stk::mesh::Part& part);
+
+class PromoteElement
+{
+public:
+  explicit PromoteElement(ElementDescription& elemDescription);
+  ~PromoteElement() {};
+
+  void promote_elements(
+    const stk::mesh::PartVector& baseParts,
+    VectorFieldType& coordinates,
+    stk::mesh::BulkData& mesh,
+    stk::mesh::PartVector& promotedParts
+  );
+
+  size_t num_sub_elements(
+    const stk::mesh::MetaData& metaData,
+    const stk::mesh::BucketVector& buckets) const;
+  size_t count_entities(const stk::mesh::BucketVector& buckets) const;
+
+  const ElementDescription& element_description() const { return elemDescription_; };
+  stk::mesh::PartVector base_part_vector() const { return baseParts_; };
+  stk::mesh::PartVector promoted_part_vector() const { return promotedParts_; };
+  unsigned nodes_per_element() const { return nodesPerElement_; };
+  unsigned added_nodes_per_element() const { return (elemDescription_.addedConnectivities.size()); };
+  unsigned base_nodes_per_element() const { return (nodes_per_element()-added_nodes_per_element()); };
+
+  stk::mesh::Entity const* begin_nodes_all(const stk::mesh::Bucket& bucket, stk::mesh::EntityId id) const;
+  stk::mesh::Entity const* begin_nodes_all(const stk::mesh::Entity& elem) const;
+  stk::mesh::Entity const* begin_elems_all(const stk::mesh::Bucket& bucket, stk::mesh::EntityId id) const;
+  stk::mesh::Entity const* begin_elems_all(const stk::mesh::Entity& elem) const;
+  stk::mesh::Entity const* begin_side_elems_all(const stk::mesh::Bucket& bucket, stk::mesh::EntityId id) const;
+  stk::mesh::Entity const* begin_side_elems_all(const stk::mesh::Entity& elem) const;
+
+  size_t num_elems(const stk::mesh::Entity& node) const;
+  size_t num_nodes(const stk::mesh::Entity& elem) const;
+private:
+  class ChildNodeRequest
+  {
+  public:
+    explicit ChildNodeRequest(std::vector<stk::mesh::EntityId>  in_parentIds);
+    ~ChildNodeRequest() = default;
+
+    bool operator==(const ChildNodeRequest& other) const
+    {
+      return parentIds_ == other.parentIds_;
+    }
+
+    void determine_sharing_procs(const stk::mesh::BulkData& mesh) const;
+    void set_node_entity_for_request(
+      stk::mesh::BulkData& mesh,
+      const stk::mesh::PartVector& node_parts
+    ) const;
+    void add_shared_elem(const stk::mesh::Entity& elem) const;
+
+    std::vector<size_t> determine_child_node_ordinal(
+      const stk::mesh::BulkData& mesh,
+      const ElementDescription& elemDesc,
+      unsigned elemNumber) const;
+
+    void set_num_children(size_t num) const
+    {
+      children_.resize(num);
+      idProcPairsFromAllProcs_.resize(num);
+    }
+
+    stk::mesh::PartVector determine_parent_parts(
+      const stk::mesh::BulkData& mesh,
+      stk::mesh::PartVector base_parts) const;
+
+    size_t num_children() const { return children_.size(); }
+    size_t num_parents() const { return parentIds_.size(); }
+
+    void add_proc_id_pair(int proc_id, stk::mesh::EntityId id, int childNumber) const;
+    stk::mesh::EntityId suggested_node_id(int childNumber) const;
+    stk::mesh::EntityId get_id_for_child(int childNumber) const;
+
+    const std::vector<stk::mesh::EntityId> parentIds_; // invariant
+    mutable std::vector<stk::mesh::EntityId> unsortedParentIds_;
+    mutable std::vector<stk::mesh::Entity> children_;
+    mutable std::vector<std::vector<size_t>> childOrdinalsForElem_;
+    mutable std::vector<std::vector<size_t>> reorderedChildOrdinalsForElem_;
+    mutable std::vector<stk::mesh::Entity> sharedElems_;
+    mutable std::vector<int> sharingProcs_;
+
+    using IdProcPair = std::pair<int,stk::mesh::EntityId>;
+    mutable std::vector<std::vector<IdProcPair>> idProcPairsFromAllProcs_;
+  };
+
+  struct EntityHash
+  {
+    std::size_t operator()(const stk::mesh::Entity& entity) const
+    {
+      return std::hash<size_t>()(entity.local_offset());
+    }
+  };
+
+  struct RequestHash
+  {
+    std::size_t operator()(const ChildNodeRequest& request) const
+    {
+      return boost::hash_range(request.parentIds_.begin(), request.parentIds_.end());
+    }
+  };
+  using NodeRequests = std::unordered_set<ChildNodeRequest, RequestHash>;
+  using ElemRelationsMap =
+      std::unordered_map<
+      stk::mesh::Entity, std::vector<stk::mesh::Entity>,
+      EntityHash>;
+
+  bool check_elem_node_relations(const stk::mesh::BulkData& mesh) const;
+
+  template<typename T> std::vector<T>
+  reorder_ordinals(
+     const std::vector<T>& ordinals,
+     const std::vector<T>& unsortedOrdinals,
+     const std::vector<T>& canonicalOrdinals,
+     unsigned numParents1D,
+     unsigned numAddedNodes1D
+   ) const;
+
+  template<unsigned embedding_dimension, unsigned dimension>
+  void interpolate_coords(
+    const std::vector<double>& isoParCoord,
+    const std::array<double, embedding_dimension*ipow(2,dimension)>& parentCoords,
+    double* interpolatedCoords
+  ) const;
+
+  template<unsigned dimension>
+  void set_new_node_coords(
+    VectorFieldType& coordinates,
+    const ElementDescription& elemDescription,
+    const stk::mesh::BulkData& mesh,
+    NodeRequests& requests
+  ) const;
+
+  template<unsigned embedding_dimension, unsigned dimension> void
+  set_coords_for_child(
+    VectorFieldType& coordinates,
+    const stk::mesh::Entity* node_rels,
+    const std::vector<size_t>& childOrdinals,
+    const std::array<stk::mesh::Entity,ipow(2,dimension)>& parentNodes,
+    const std::vector<std::vector<double>>& isoParCoords) const;
+
+  NodeRequests create_child_node_requests(
+    stk::mesh::BulkData& mesh,
+    const ElementDescription& elemDescription,
+    const stk::mesh::Selector& selector
+  ) const;
+
+  void batch_create_child_nodes(
+    stk::mesh::BulkData & mesh,
+    NodeRequests& requests,
+    const stk::mesh::PartVector& node_parts
+  ) const;
+
+  void parallel_communicate_ids(
+    const stk::mesh::BulkData& mesh,
+    NodeRequests& requests) const;
+
+  void populate_elem_node_relations(
+    const ElementDescription& elemDescription,
+    stk::mesh::BulkData& mesh,
+    const stk::mesh::Selector selector,
+    const NodeRequests& requests
+  );
+
+  size_t count_nodes(
+    const stk::mesh::PartVector& baseParts,
+    const stk::mesh::PartVector& promotedParts) const;
+  size_t count_requested_nodes(const NodeRequests& requests) const;
+
+  const ElementDescription& elemDescription_;
+  const unsigned nodesPerElement_;
+  const unsigned dimension_;
+
+  //local copy
+  stk::mesh::PartVector baseParts_;
+  stk::mesh::PartVector promotedParts_;
+
+  ElemRelationsMap elemNodeMap_;
+  ElemRelationsMap nodeElemMap_;
+
+  ElemRelationsMap elemNodeMapBC_;
+  ElemRelationsMap nodeElemMapBC_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/element_promotion/PromotedElementIO.h
+++ b/include/element_promotion/PromotedElementIO.h
@@ -1,0 +1,135 @@
+#ifndef PromotedElementIO_h
+#define PromotedElementIO_h
+
+#include <stk_mesh/base/CoordinateSystems.hpp>
+#include <stk_mesh/base/FieldBase.hpp>
+#include <Ioss_Region.h>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/Types.hpp>
+
+#include <stddef.h>
+#include <iosfwd>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace Ioss {
+class DatabaseIO;
+class ElementBlock;
+class NodeBlock;
+class SideBlock;
+}  // namespace Ioss
+namespace sierra {
+namespace nalu {
+class PromoteElement;
+struct ElementDescription;
+}  // namespace nalu
+}  // namespace sierra
+
+// field types
+typedef stk::mesh::Field<double>  ScalarFieldType;
+typedef stk::mesh::Field<double, stk::mesh::SimpleArrayTag>  GenericFieldType;
+typedef stk::mesh::Field<double, stk::mesh::Cartesian>  VectorFieldType;
+
+namespace stk {
+  namespace mesh {
+    class BulkData;
+    class MetaData;
+    class Part;
+
+    typedef std::vector<Part*> PartVector;
+  }
+}
+
+namespace sierra {
+namespace nalu {
+
+class PromotedElementIO
+{
+
+public:
+  // constructor/destructor
+  PromotedElementIO(
+    const PromoteElement& promoteElement,
+    const stk::mesh::MetaData& metaData,
+    const stk::mesh::BulkData& bulkData,
+    const VectorFieldType& coordinates,
+    const std::string& fileName
+  );
+
+  virtual ~PromotedElementIO() = default;
+
+  void output_results(const std::vector<const stk::mesh::FieldBase*> fields) const;
+
+  void write_database_data(double currentTime);
+
+  void write_element_connectivity(
+    const stk::mesh::PartVector& baseParts,
+    const std::vector<stk::mesh::EntityId>& entityIds);
+
+  void write_sideset_connectivity(
+      const stk::mesh::PartVector& baseParts);
+
+  size_t sub_element_global_id() const;
+  void write_node_block_definitions(
+    const stk::mesh::PartVector& baseParts,
+    const stk::mesh::PartVector& promotedParts);
+  void write_elem_block_definitions(const stk::mesh::PartVector& baseParts);
+  void write_sideset_definitions(const stk::mesh::PartVector& baseParts);
+  void write_coordinate_list(
+    const stk::mesh::PartVector& baseParts,
+    const stk::mesh::PartVector& promotedParts);
+
+  void add_fields(const std::vector<stk::mesh::FieldBase*>& fields);
+  bool check_topology(const stk::mesh::PartVector& baseParts) const;
+  int maximum_field_length(const stk::mesh::FieldBase& field) const;
+
+  template<typename T> void
+  put_data_on_node_block(
+    Ioss::NodeBlock& nodeBlock,
+    const stk::mesh::FieldBase& field,
+    const stk::mesh::BucketVector& buckets,
+    size_t numNodes) const;
+
+  std::string storage_name(const stk::mesh::FieldBase& field) const;
+
+  // meta, bulk and io
+  const PromoteElement& promoteElement_;
+  const stk::mesh::MetaData& metaData_;
+  const stk::mesh::BulkData& bulkData_;
+  const VectorFieldType& coordinates_;
+  const std::string& fileName_;
+  const ElementDescription& elem_;
+  const unsigned nDim_;
+
+  struct FieldNameHash {
+    std::size_t operator()(const stk::mesh::FieldBase* const  field) const  {
+      return std::hash<std::string>()(field->name());
+    }
+  };
+
+  struct FieldNameEqual {
+    bool operator()(const stk::mesh::FieldBase* fieldA, const stk::mesh::FieldBase* fieldB) const {
+      return (fieldA->name() == fieldB->name());
+    }
+  };
+  std::unordered_set<const stk::mesh::FieldBase*, FieldNameHash, FieldNameEqual> fields_;
+
+  std::map<const stk::mesh::Part*, Ioss::ElementBlock*> elementBlockPointers_;
+  std::map<const stk::mesh::Part*, Ioss::SideBlock*> sideBlockPointers_;
+  Ioss::NodeBlock* nodeBlock_;
+
+  std::unique_ptr<Ioss::Region> output_;
+  Ioss::DatabaseIO* databaseIO;
+
+  // fields
+
+
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/element_promotion/QuadratureRule.h
+++ b/include/element_promotion/QuadratureRule.h
@@ -1,0 +1,25 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+#ifndef QuadratureRule_h
+#define QuadratureRule_h
+
+#include <vector>
+#include <Teuchos_SerialDenseVector.hpp>
+
+namespace sierra{
+namespace nalu{
+
+  std::pair<std::vector<double>, std::vector<double>>
+  gauss_legendre_rule(int order);
+
+  std::pair<std::vector<double>, std::vector<double>>
+  gauss_lobatto_legendre_rule(int order, double xleft = -1.0, double xright = +1.0);
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/element_promotion/TensorProductQuadratureRule.h
+++ b/include/element_promotion/TensorProductQuadratureRule.h
@@ -1,0 +1,61 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+#ifndef TensorProductQuadratureRule_h
+#define TensorProductQuadratureRule_h
+
+#include <string>
+#include <vector>
+
+namespace sierra{
+namespace nalu{
+
+class TensorProductQuadratureRule
+{
+public:
+  TensorProductQuadratureRule(
+    std::string type,
+    int numQuad,
+    std::vector<double>& scsLocs
+  );
+  ~TensorProductQuadratureRule() {};
+
+  std::vector<double>& abscissae() { return abscissae_; };
+  std::vector<double>& weights() { return weights_; };
+  std::vector<double>& scsEndLoc() { return scsEndLoc_; };
+
+  double abscissa(unsigned j) const { return abscissae_[j]; };
+  double weight(unsigned j) const { return weights_[j]; };
+
+  double gauss_point_location(
+    int nodeOrdinal,
+    int gaussPointOrdinal) const;
+
+  double tensor_product_weight(
+    int s1Node, int s2Node, int s3Node,
+    int s1Ip, int s2Ip, int s3Ip) const;
+
+  double tensor_product_weight(
+    int s1Node, int s2Node,
+    int s1Ip, int s2Ip) const;
+
+  double tensor_product_weight(int s1Node, int s1Ip) const;
+
+  double isoparametric_mapping(
+    const double b,
+    const double a,
+    const double xi) const;
+
+private:
+  std::vector<double> abscissae_;
+  std::vector<double> weights_;
+  std::vector<double> scsEndLoc_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/nalu_make_unique.h
+++ b/include/nalu_make_unique.h
@@ -1,0 +1,15 @@
+#ifndef nalu_make_unique_h
+#define nalu_make_unique_h
+
+namespace sierra {
+namespace nalu {
+template<typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+}
+}
+
+#endif

--- a/include/overset/OversetInfo.h
+++ b/include/overset/OversetInfo.h
@@ -53,6 +53,6 @@ class OversetInfo {
 };
   
 } // end sierra namespace
-} // end naluUnit namespace
+} // end nalu namespace
 
 #endif

--- a/include/overset/OversetManager.h
+++ b/include/overset/OversetManager.h
@@ -1,7 +1,7 @@
 /*------------------------------------------------------------------------*/
 /*  Copyright 2014 Sandia Corporation.                                    */
 /*  This software is released under the license detailed                  */
-/*  in the file, LICENSE, which is located in the top-level NaluUnit      */
+/*  in the file, LICENSE, which is located in the top-level nalu      */
 /*  directory structure                                                   */
 /*------------------------------------------------------------------------*/
 
@@ -180,7 +180,7 @@ public:
 
 };
 
-} // namespace naluUnit
+} // namespace nalu
 } // namespace Sierra
 
 #endif

--- a/include/user_functions/SteadyThermalContact3DAuxFunction.h
+++ b/include/user_functions/SteadyThermalContact3DAuxFunction.h
@@ -1,0 +1,46 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef SteadyThermalContact3DAuxFunction_h
+#define SteadyThermalContact3DAuxFunction_h
+
+#include <AuxFunction.h>
+
+#include <vector>
+
+namespace sierra{
+namespace nalu{
+
+class SteadyThermalContact3DAuxFunction : public AuxFunction
+{
+public:
+
+  SteadyThermalContact3DAuxFunction();
+
+  virtual ~SteadyThermalContact3DAuxFunction() {}
+  
+  virtual void do_evaluate(
+    const double * coords,
+    const double time,
+    const unsigned spatialDimension,
+    const unsigned numPoints,
+    double * fieldPtr,
+    const unsigned fieldSize,
+    const unsigned beginPos,
+    const unsigned endPos) const;
+  
+private:
+  double a_;
+  double k_;
+  double pi_;
+
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/user_functions/SteadyThermalContact3DSrcElemSuppAlg.h
+++ b/include/user_functions/SteadyThermalContact3DSrcElemSuppAlg.h
@@ -1,0 +1,68 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef SteadyThermalContac3DtSrcElemSuppAlg_h
+#define SteadyThermalContact3DSrcElemSuppAlg_h
+
+#include <SupplementalAlgorithm.h>
+#include <FieldTypeDef.h>
+
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Entity.hpp>
+
+namespace sierra{
+namespace nalu{
+
+class Realm;
+class MasterElement;
+
+class SteadyThermalContact3DSrcElemSuppAlg : public SupplementalAlgorithm
+{
+public:
+
+  SteadyThermalContact3DSrcElemSuppAlg(
+    Realm &realm);
+
+  virtual ~SteadyThermalContact3DSrcElemSuppAlg() {}
+
+  virtual void setup();
+
+  virtual void elem_resize(
+    MasterElement *meSCS,
+    MasterElement *meSCV);
+
+  virtual void elem_execute(
+    double *lhs,
+    double *rhs,
+    stk::mesh::Entity element,
+    MasterElement *meSCS,
+    MasterElement *meSCV);
+  
+  const stk::mesh::BulkData *bulkData_;
+
+  VectorFieldType *coordinates_;
+
+  const double a_;
+  const double k_;
+  const double pi_;
+  const bool useShifted_;
+  const int nDim_;
+  const bool evalAtIps_;
+
+  // scratch space
+  std::vector<double> scvCoords_;
+  std::vector<double> ws_shape_function_;
+  std::vector<double> ws_coordinates_;
+  std::vector<double> ws_scv_volume_;
+  std::vector<double> ws_nodalSrc_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/user_functions/SteadyThermalContact3DSrcNodeSuppAlg.h
+++ b/include/user_functions/SteadyThermalContact3DSrcNodeSuppAlg.h
@@ -1,0 +1,49 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef SteadyThermalContact3DSrcNodeSuppAlg_h
+#define SteadyThermalContact3DSrcNodeSuppAlg_h
+
+#include <SupplementalAlgorithm.h>
+#include <FieldTypeDef.h>
+
+#include <stk_mesh/base/Entity.hpp>
+
+namespace sierra{
+namespace nalu{
+
+class Realm;
+
+class SteadyThermalContact3DSrcNodeSuppAlg : public SupplementalAlgorithm
+{
+public:
+
+  SteadyThermalContact3DSrcNodeSuppAlg(
+    Realm &realm);
+
+  virtual ~SteadyThermalContact3DSrcNodeSuppAlg() {}
+
+  virtual void setup();
+
+  virtual void node_execute(
+    double *lhs,
+    double *rhs,
+    stk::mesh::Entity node);
+  
+  VectorFieldType *coordinates_;
+  ScalarFieldType *dualNodalVolume_;
+  double a_;
+  double k_;
+  double pi_;
+  
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/src/AssembleContinuityEdgeContactSolverAlgorithm.C
+++ b/src/AssembleContinuityEdgeContactSolverAlgorithm.C
@@ -87,9 +87,7 @@ AssembleContinuityEdgeContactSolverAlgorithm::initialize_connectivity()
 void
 AssembleContinuityEdgeContactSolverAlgorithm::execute()
 {
-
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
 
   const int nDim = meta_data.spatial_dimension();
 
@@ -185,8 +183,8 @@ AssembleContinuityEdgeContactSolverAlgorithm::execute()
       // extract element mesh object and global id for face node
       stk::mesh::Entity elem  = infoObject->owningElement_;
 
-      stk::mesh::Entity const* elem_node_rels = bulk_data.begin_nodes(elem);
-      const int num_nodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const* elem_node_rels = realm_.begin_nodes_all(elem);
+      const int num_nodes = realm_.num_nodes_all(elem);
 
       // now load the elemental values for future interpolation; fill in connected nodes
       connected_nodes[0] = infoObject->faceNode_;

--- a/src/AssembleContinuityEdgeOpenSolverAlgorithm.C
+++ b/src/AssembleContinuityEdgeOpenSolverAlgorithm.C
@@ -77,7 +77,6 @@ void
 AssembleContinuityEdgeOpenSolverAlgorithm::execute()
 {
 
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -160,8 +159,8 @@ AssembleContinuityEdgeOpenSolverAlgorithm::execute()
       theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
 
       // get the relations from element
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
-      int num_nodes = bulk_data.num_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
+      int num_nodes = realm_.num_nodes_all(element);
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );
       for ( int ni = 0; ni < num_nodes; ++ni ) {

--- a/src/AssembleContinuityEdgeSolverAlgorithm.C
+++ b/src/AssembleContinuityEdgeSolverAlgorithm.C
@@ -127,9 +127,9 @@ AssembleContinuityEdgeSolverAlgorithm::execute()
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
 
       // sanity check on number or nodes
-      ThrowAssert( b.num_nodes(k) == 2 );
+      ThrowAssert( realm_.num_nodes_all(b,k) == 2 );
 
-      stk::mesh::Entity const * edge_node_rels = b.begin_nodes(k);
+      stk::mesh::Entity const * edge_node_rels = realm_.begin_nodes_all(b,k);
 
       // pointer to edge area vector
       for ( int j = 0; j < nDim; ++j )

--- a/src/AssembleContinuityElemOpenSolverAlgorithm.C
+++ b/src/AssembleContinuityElemOpenSolverAlgorithm.C
@@ -162,7 +162,7 @@ AssembleContinuityElemOpenSolverAlgorithm::execute()
 
     // face master element
     MasterElement *meFC = realm_.get_surface_master_element(b.topology());
-    const int nodesPerFace = b.topology().num_nodes();
+    const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsBip = meFC->numIntPoints_;
     std::vector<int> face_node_ordinal_vec(nodesPerFace);
 
@@ -228,8 +228,8 @@ AssembleContinuityElemOpenSolverAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
-      int num_face_nodes = bulk_data.num_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
+      int num_face_nodes = realm_.num_nodes_all(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -260,7 +260,7 @@ AssembleContinuityElemOpenSolverAlgorithm::execute()
       stk::mesh::Entity element = face_elem_rels[0];
       const stk::mesh::ConnectivityOrdinal* face_elem_ords = bulk_data.begin_element_ordinals(face);
       const int face_ordinal = face_elem_ords[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinal_vec.begin());
+      realm_.side_node_ordinals_all(theElemTopo, face_ordinal, face_node_ordinal_vec);
 
       // mapping from ip to nodes for this ordinal
       const int *ipNodeMap = meSCS->ipNodeMap(face_ordinal);
@@ -268,8 +268,8 @@ AssembleContinuityElemOpenSolverAlgorithm::execute()
       //======================================
       // gather nodal data off of element
       //======================================
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
-      int num_nodes = bulk_data.num_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
+      int num_nodes = realm_.num_nodes_all(element);
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );
       for ( int ni = 0; ni < num_nodes; ++ni ) {
@@ -376,7 +376,6 @@ AssembleContinuityElemOpenSolverAlgorithm::execute()
       }
 
       apply_coeff(connected_nodes, rhs, lhs, __FILE__);
-
     }
   }
 }

--- a/src/AssembleContinuityElemSolverAlgorithm.C
+++ b/src/AssembleContinuityElemSolverAlgorithm.C
@@ -212,8 +212,8 @@ AssembleContinuityElemSolverAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const *  node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );

--- a/src/AssembleContinuityInflowSolverAlgorithm.C
+++ b/src/AssembleContinuityInflowSolverAlgorithm.C
@@ -156,9 +156,9 @@ AssembleContinuityInflowSolverAlgorithm::execute()
       double * areaVec = stk::mesh::field_data(*exposedAreaVec_, b, k);
 
       // face node relations for nodal gather
-      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(b,k);
 
-      int num_nodes = b.num_nodes(k);
+      int num_nodes = realm_.num_nodes_all(b,k);
       for ( int ni = 0; ni < num_nodes; ++ni ) {
 
         // get the node and form connected_node

--- a/src/AssembleCourantReynoldsElemAlgorithm.C
+++ b/src/AssembleCourantReynoldsElemAlgorithm.C
@@ -74,7 +74,6 @@ void
 AssembleCourantReynoldsElemAlgorithm::execute()
 {
 
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -138,8 +137,8 @@ AssembleCourantReynoldsElemAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * node_rels = bulk_data.begin_nodes(elem);
-      int num_nodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const * node_rels = realm_.begin_nodes_all(elem);
+      int num_nodes = realm_.num_nodes_all(elem);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );

--- a/src/AssembleElemSolverAlgorithm.C
+++ b/src/AssembleElemSolverAlgorithm.C
@@ -113,8 +113,8 @@ AssembleElemSolverAlgorithm::execute()
       stk::mesh::Entity element = b[k];
 
       // extract node relations and provide connected nodes
-      stk::mesh::Entity const * node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );

--- a/src/AssembleHeatCondIrradWallSolverAlgorithm.C
+++ b/src/AssembleHeatCondIrradWallSolverAlgorithm.C
@@ -143,9 +143,9 @@ AssembleHeatCondIrradWallSolverAlgorithm::execute()
       double * areaVec = stk::mesh::field_data(*exposedAreaVec_, b, k);
 
       // face node relations for nodal gather
-      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(b,k);
       
-      int num_nodes = b.num_nodes(k);
+      int num_nodes = realm_.num_nodes_all(b,k);
       for ( int ni = 0; ni < num_nodes; ++ni ) {
 
         // get the node and form connected_node

--- a/src/AssembleHeatCondWallSolverAlgorithm.C
+++ b/src/AssembleHeatCondWallSolverAlgorithm.C
@@ -144,9 +144,9 @@ AssembleHeatCondWallSolverAlgorithm::execute()
       double * areaVec = stk::mesh::field_data(*exposedAreaVec_, b, k);
 
       // face node relations for nodal gather
-      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(b,k);
       
-      int num_nodes = b.num_nodes(k);
+      int num_nodes = realm_.num_nodes_all(b,k);
       for ( int ni = 0; ni < num_nodes; ++ni ) {
 
         // get the node and form connected_node

--- a/src/AssembleMomentumEdgeContactSolverAlgorithm.C
+++ b/src/AssembleMomentumEdgeContactSolverAlgorithm.C
@@ -99,7 +99,6 @@ AssembleMomentumEdgeContactSolverAlgorithm::execute()
 {
 
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
 
   const int nDim = meta_data.spatial_dimension();
 
@@ -224,8 +223,8 @@ AssembleMomentumEdgeContactSolverAlgorithm::execute()
       // extract element mesh object and global id for face node
       stk::mesh::Entity elem  = infoObject->owningElement_;
 
-      stk::mesh::Entity const* elem_node_rels = bulk_data.begin_nodes(elem);
-      const int num_nodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const* elem_node_rels = realm_.begin_nodes_all(elem);
+      const int num_nodes = realm_.num_nodes_all(elem);
 
       // now load the elemental values for future interpolation; fill in connected nodes
       connected_nodes[0] = infoObject->faceNode_;

--- a/src/AssembleMomentumEdgeOpenSolverAlgorithm.C
+++ b/src/AssembleMomentumEdgeOpenSolverAlgorithm.C
@@ -72,7 +72,6 @@ void
 AssembleMomentumEdgeOpenSolverAlgorithm::execute()
 {
 
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -159,8 +158,8 @@ AssembleMomentumEdgeOpenSolverAlgorithm::execute()
       theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
 
       // get the relations; populate connected nodes
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
-      int num_nodes = bulk_data.num_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
+      int num_nodes = realm_.num_nodes_all(element);
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );
       for ( int ni = 0; ni < num_nodes; ++ni ) {

--- a/src/AssembleMomentumEdgeSolverAlgorithm.C
+++ b/src/AssembleMomentumEdgeSolverAlgorithm.C
@@ -179,7 +179,7 @@ AssembleMomentumEdgeSolverAlgorithm::execute()
         p_rhs[i] = 0.0;
       }
 
-      stk::mesh::Entity const * edge_node_rels = b.begin_nodes(k);
+      stk::mesh::Entity const * edge_node_rels = realm_.begin_nodes_all(b,k);
 
       // pointer to edge area vector
       for ( int j = 0; j < nDim; ++j )
@@ -187,7 +187,7 @@ AssembleMomentumEdgeSolverAlgorithm::execute()
       const double tmdot = mdot[k];
 
       // sanity check on number or nodes
-      ThrowAssert( b.num_nodes(k) == 2 );
+      ThrowAssert( realm_.num_nodes_all(b,k) == 2 );
 
       // left and right nodes
       stk::mesh::Entity nodeL = edge_node_rels[0];

--- a/src/AssembleMomentumEdgeSymmetrySolverAlgorithm.C
+++ b/src/AssembleMomentumEdgeSymmetrySolverAlgorithm.C
@@ -70,7 +70,6 @@ void
 AssembleMomentumEdgeSymmetrySolverAlgorithm::execute()
 {
 
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -152,8 +151,8 @@ AssembleMomentumEdgeSymmetrySolverAlgorithm::execute()
       theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
 
       // get the relations; populate connected nodes
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
-      int num_nodes = bulk_data.num_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
+      int num_nodes = realm_.num_nodes_all(element);
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );
       for ( int ni = 0; ni < num_nodes; ++ni ) {

--- a/src/AssembleMomentumElemOpenSolverAlgorithm.C
+++ b/src/AssembleMomentumElemOpenSolverAlgorithm.C
@@ -222,8 +222,8 @@ AssembleMomentumElemOpenSolverAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
-      int num_face_nodes = bulk_data.num_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
+      int num_face_nodes = realm_.num_nodes_all(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -258,7 +258,7 @@ AssembleMomentumElemOpenSolverAlgorithm::execute()
       stk::mesh::Entity element = face_elem_rels[0];
       const stk::mesh::ConnectivityOrdinal* face_elem_ords = bulk_data.begin_element_ordinals(face);
       const int face_ordinal = face_elem_ords[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinal_vec.begin());
+      realm_.side_node_ordinals_all(theElemTopo, face_ordinal, face_node_ordinal_vec);
 
       // mapping from ip to nodes for this ordinal
       const int *ipNodeMap = meSCS->ipNodeMap(face_ordinal);
@@ -267,8 +267,8 @@ AssembleMomentumElemOpenSolverAlgorithm::execute()
       //==========================================
       // gather nodal data off of element
       //==========================================
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
-      int num_nodes = bulk_data.num_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
+      int num_nodes = realm_.num_nodes_all(element);
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );
       for ( int ni = 0; ni < num_nodes; ++ni ) {

--- a/src/AssembleMomentumElemSolverAlgorithm.C
+++ b/src/AssembleMomentumElemSolverAlgorithm.C
@@ -265,8 +265,8 @@ AssembleMomentumElemSolverAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );

--- a/src/AssembleMomentumElemSymmetrySolverAlgorithm.C
+++ b/src/AssembleMomentumElemSymmetrySolverAlgorithm.C
@@ -166,8 +166,8 @@ AssembleMomentumElemSymmetrySolverAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
-      int num_face_nodes = bulk_data.num_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
+      int num_face_nodes = realm_.num_nodes_all(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -194,8 +194,8 @@ AssembleMomentumElemSymmetrySolverAlgorithm::execute()
       //==========================================
       // gather nodal data off of element
       //==========================================
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
-      int num_nodes = bulk_data.num_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
+      int num_nodes = realm_.num_nodes_all(element);
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );
       for ( int ni = 0; ni < num_nodes; ++ni ) {

--- a/src/AssembleMomentumWallFunctionSolverAlgoirthm.C
+++ b/src/AssembleMomentumWallFunctionSolverAlgoirthm.C
@@ -76,7 +76,6 @@ void
 AssembleMomentumWallFunctionSolverAlgorithm::execute()
 {
 
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -169,7 +168,7 @@ AssembleMomentumWallFunctionSolverAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
       for ( int ni = 0; ni < nodesPerFace; ++ni ) {
         stk::mesh::Entity node = face_node_rels[ni];
         connected_nodes[ni] = node;

--- a/src/AssembleNodalGradBoundaryAlgorithm.C
+++ b/src/AssembleNodalGradBoundaryAlgorithm.C
@@ -109,8 +109,8 @@ AssembleNodalGradBoundaryAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerFace );

--- a/src/AssembleNodalGradEdgeAlgorithm.C
+++ b/src/AssembleNodalGradEdgeAlgorithm.C
@@ -79,10 +79,10 @@ AssembleNodalGradEdgeAlgorithm::execute()
     double * av = stk::mesh::field_data(*edgeAreaVec_, b);
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
 
-      stk::mesh::Entity const * edge_node_rels = b.begin_nodes(k);
+      stk::mesh::Entity const * edge_node_rels = realm_.begin_nodes_all(b,k);
 
       // sanity check on number or nodes
-      ThrowAssert( b.num_nodes(k) == 2 );
+      ThrowAssert( realm_.num_nodes_all(b,k) == 2 );
 
       // left and right nodes
       stk::mesh::Entity nodeL = edge_node_rels[0];

--- a/src/AssembleNodalGradEdgeContactAlgorithm.C
+++ b/src/AssembleNodalGradEdgeContactAlgorithm.C
@@ -66,8 +66,6 @@ AssembleNodalGradEdgeContactAlgorithm::execute()
 {
 
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
-
   const int nDim = meta_data.spatial_dimension();
 
   // parallel communicate ghosted entities
@@ -100,8 +98,8 @@ AssembleNodalGradEdgeContactAlgorithm::execute()
       // extract halo info stuff; can remove edge area vec...
       const double *p_areaVec = &infoObject->haloEdgeAreaVec_[0];
 
-      stk::mesh::Entity const *elem_node_rels = bulk_data.begin_nodes(elem);
-      const unsigned num_nodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const *elem_node_rels = realm_.begin_nodes_all(elem);
+      const unsigned num_nodes = realm_.num_nodes_all(elem);
 
       // now load the elemental values for future interpolation
       for ( unsigned ni = 0; ni < num_nodes; ++ni ) {

--- a/src/AssembleNodalGradElemContactAlgorithm.C
+++ b/src/AssembleNodalGradElemContactAlgorithm.C
@@ -110,8 +110,8 @@ AssembleNodalGradElemContactAlgorithm::populate_halo_state()
       // extract element mesh object and global id for face node
       stk::mesh::Entity elem  = infoObject->owningElement_;
 
-      stk::mesh::Entity const *elem_node_rels = bulk_data.begin_nodes(elem);
-      const unsigned num_nodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const *elem_node_rels = realm_.begin_nodes_all(elem);
+      const unsigned num_nodes = realm_.num_nodes_all(elem);
       
       // now load the elemental values for future interpolation
       for ( unsigned ni = 0; ni < num_nodes; ++ni ) {
@@ -224,8 +224,8 @@ AssembleNodalGradElemContactAlgorithm::add_elem_gradq()
       theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
       
       // concentrate on loading up the nodal coordinates/scalarQ for the extruded element
-      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
       for ( int ni = 0; ni < num_nodes; ++ni ) {
         stk::mesh::Entity node = face_node_rels[ni];
         const double * coords = stk::mesh::field_data(*coordinates, node);
@@ -272,7 +272,7 @@ AssembleNodalGradElemContactAlgorithm::add_elem_gradq()
       }
       
       // deal with edges on the exposed face and each
-      stk::mesh::Entity const* elem_node_rels = bulk_data.begin_nodes(element);
+      stk::mesh::Entity const* elem_node_rels = realm_.begin_nodes_all(element);
       
       // face edge relations; if this is 2D then the face is a edge and size is unity
       stk::mesh::Entity const* face_edge_rels = bulk_data.begin_edges(face);

--- a/src/AssembleNodalGradUBoundaryAlgorithm.C
+++ b/src/AssembleNodalGradUBoundaryAlgorithm.C
@@ -112,8 +112,8 @@ AssembleNodalGradUBoundaryAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerFace );

--- a/src/AssembleNodalGradUEdgeAlgorithm.C
+++ b/src/AssembleNodalGradUEdgeAlgorithm.C
@@ -76,10 +76,10 @@ AssembleNodalGradUEdgeAlgorithm::execute()
     double * av = stk::mesh::field_data(*edgeAreaVec_, b);
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
 
-      stk::mesh::Entity const * edge_node_rels = b.begin_nodes(k);
+      stk::mesh::Entity const * edge_node_rels = realm_.begin_nodes_all(b,k);
 
       // sanity check on number or nodes
-      ThrowAssert( b.num_nodes(k) == 2 );
+      ThrowAssert( realm_.num_nodes_all(b,k) == 2 );
 
       // left and right nodes
       stk::mesh::Entity nodeL = edge_node_rels[0];

--- a/src/AssembleNodalGradUEdgeContactAlgorithm.C
+++ b/src/AssembleNodalGradUEdgeContactAlgorithm.C
@@ -66,8 +66,6 @@ AssembleNodalGradUEdgeContactAlgorithm::execute()
 {
 
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
-
   const int nDim = meta_data.spatial_dimension();
 
   // space for interpolated right state (halo)
@@ -103,8 +101,8 @@ AssembleNodalGradUEdgeContactAlgorithm::execute()
       // extract halo info stuff; can remove edge area vec...
       const double *p_areaVec = &infoObject->haloEdgeAreaVec_[0];
 
-      stk::mesh::Entity const* elem_node_rels = bulk_data.begin_nodes(elem);
-      const int num_nodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const* elem_node_rels = realm_.begin_nodes_all(elem);
+      const int num_nodes = realm_.num_nodes_all(elem);
 
       // now load the elemental values for future interpolation
       for ( int ni = 0; ni < num_nodes; ++ni ) {

--- a/src/AssembleNodalGradUElemAlgorithm.C
+++ b/src/AssembleNodalGradUElemAlgorithm.C
@@ -118,8 +118,8 @@ AssembleNodalGradUElemAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );

--- a/src/AssembleNodalGradUElemContactAlgorithm.C
+++ b/src/AssembleNodalGradUElemContactAlgorithm.C
@@ -115,8 +115,8 @@ AssembleNodalGradUElemContactAlgorithm::populate_halo_state()
       // extract element mesh object and global id for face node
       stk::mesh::Entity elem  = infoObject->owningElement_;
 
-      stk::mesh::Entity const *elem_node_rels = bulk_data.begin_nodes(elem);
-      const unsigned num_nodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const *elem_node_rels = realm_.begin_nodes_all(elem);
+      const unsigned num_nodes = realm_.num_nodes_all(elem);
       
       // now load the elemental values for future interpolation
       for ( unsigned ni = 0; ni < num_nodes; ++ni ) {
@@ -231,8 +231,8 @@ AssembleNodalGradUElemContactAlgorithm::add_elem_gradq()
       theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
       
       // concentrate on loading up the nodal coordinates/vectorQ for the extruded element
-      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
       for ( int ni = 0; ni < num_nodes; ++ni ) {
         stk::mesh::Entity node = face_node_rels[ni];
         const double * coords = stk::mesh::field_data(*coordinates, node);
@@ -287,7 +287,7 @@ AssembleNodalGradUElemContactAlgorithm::add_elem_gradq()
       }
       
       // deal with edges on the exposed face and each
-      stk::mesh::Entity const* elem_node_rels = bulk_data.begin_nodes(element);
+      stk::mesh::Entity const* elem_node_rels = realm_.begin_nodes_all(element);
       
       // face edge relations; if this is 2D then the face is a edge and size is unity
       stk::mesh::Entity const* face_edge_rels = bulk_data.begin_edges(face);

--- a/src/AssemblePNGBoundarySolverAlgorithm.C
+++ b/src/AssemblePNGBoundarySolverAlgorithm.C
@@ -131,8 +131,8 @@ AssemblePNGBoundarySolverAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
-      int num_face_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(b,k);
+      int num_face_nodes = realm_.num_nodes_all(b,k);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {

--- a/src/AssemblePNGElemSolverAlgorithm.C
+++ b/src/AssemblePNGElemSolverAlgorithm.C
@@ -158,8 +158,8 @@ AssemblePNGElemSolverAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );

--- a/src/AssembleScalarEdgeContactSolverAlgorithm.C
+++ b/src/AssembleScalarEdgeContactSolverAlgorithm.C
@@ -103,7 +103,6 @@ AssembleScalarEdgeContactSolverAlgorithm::execute()
 {
 
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
 
   const int nDim = meta_data.spatial_dimension();
 
@@ -205,8 +204,8 @@ AssembleScalarEdgeContactSolverAlgorithm::execute()
       // extract element mesh object and global id for face node
       stk::mesh::Entity elem  = infoObject->owningElement_;
 
-      stk::mesh::Entity const* elem_node_rels = bulk_data.begin_nodes(elem);
-      const int num_nodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const* elem_node_rels = realm_.begin_nodes_all(elem);
+      const int num_nodes = realm_.num_nodes_all(elem);
 
       // now load the elemental values for future interpolation; fill in connected nodes
       connected_nodes[0] = infoObject->faceNode_;

--- a/src/AssembleScalarEdgeDiffContactSolverAlgorithm.C
+++ b/src/AssembleScalarEdgeDiffContactSolverAlgorithm.C
@@ -94,8 +94,6 @@ AssembleScalarEdgeDiffContactSolverAlgorithm::execute()
 {
 
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
-
   const int nDim = meta_data.spatial_dimension();
 
   // space for LHS/RHS (nodesPerElem+1)*(nodesPerElem+1); nodesPerElem+1
@@ -168,8 +166,8 @@ AssembleScalarEdgeDiffContactSolverAlgorithm::execute()
       // extract element mesh object and global id for face node
       stk::mesh::Entity elem  = infoObject->owningElement_;
 
-      stk::mesh::Entity const* elem_node_rels = bulk_data.begin_nodes(elem);
-      const int num_nodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const* elem_node_rels = realm_.begin_nodes_all(elem);
+      const int num_nodes = realm_.num_nodes_all(elem);
 
       // now load the elemental values for future interpolation; fill in connected nodes
       connected_nodes[0] = infoObject->faceNode_;

--- a/src/AssembleScalarEdgeOpenSolverAlgorithm.C
+++ b/src/AssembleScalarEdgeOpenSolverAlgorithm.C
@@ -148,13 +148,13 @@ AssembleScalarEdgeOpenSolverAlgorithm::execute()
       // get element; its face ordinal number and populate face_node_ordinal_vec
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = bulk_data.begin_element_ordinals(face)[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinal_vec.begin());
+              realm_.side_node_ordinals_all(theElemTopo, face_ordinal, face_node_ordinal_vec);
 
       //==========================================
       // gather nodal data off of element; n/a
       //==========================================
-      const stk::mesh::Entity* elem_node_rels = bulk_data.begin_nodes(element);
-      const int num_nodes = bulk_data.num_nodes(element);
+      const stk::mesh::Entity* elem_node_rels = realm_.begin_nodes_all(element);
+      const int num_nodes = realm_.num_nodes_all(element);
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );
       for ( int ni = 0; ni < num_nodes; ++ni ) {

--- a/src/AssembleScalarElemDiffSolverAlgorithm.C
+++ b/src/AssembleScalarElemDiffSolverAlgorithm.C
@@ -94,11 +94,11 @@ AssembleScalarElemDiffSolverAlgorithm::execute()
   ScalarElemDiffusionFunctor * diffusionOperator;
 
   if (useCollocation_){
-    diffusionOperator = new CollocationScalarElemDiffusionFunctor(bulk_data, meta_data,
+    diffusionOperator = new CollocationScalarElemDiffusionFunctor(realm_,bulk_data, meta_data,
       scalarQNp1, *diffFluxCoeff_, *coordinates_, nDim);
   }
   else{
-    diffusionOperator = new CVFEMScalarElemDiffusionFunctor(bulk_data, meta_data,
+    diffusionOperator = new CVFEMScalarElemDiffusionFunctor(realm_, bulk_data, meta_data,
       scalarQNp1, *diffFluxCoeff_, *coordinates_, nDim);
    }
 

--- a/src/AssembleScalarElemOpenSolverAlgorithm.C
+++ b/src/AssembleScalarElemOpenSolverAlgorithm.C
@@ -202,8 +202,8 @@ AssembleScalarElemOpenSolverAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
-      int num_face_nodes = bulk_data.num_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
+      int num_face_nodes = realm_.num_nodes_all(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -228,7 +228,7 @@ AssembleScalarElemOpenSolverAlgorithm::execute()
       // get element; its face ordinal number and populate face_node_ordinal_vec
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = bulk_data.begin_element_ordinals(face)[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinal_vec.begin());
+      realm_.side_node_ordinals_all(theElemTopo, face_ordinal, face_node_ordinal_vec);
 
       // mapping from ip to nodes for this ordinal
       const int *ipNodeMap = meSCS->ipNodeMap(face_ordinal);
@@ -236,8 +236,8 @@ AssembleScalarElemOpenSolverAlgorithm::execute()
       //==========================================
       // gather nodal data off of element; n/a
       //==========================================
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
-      int num_nodes = bulk_data.num_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
+      int num_nodes = realm_.num_nodes_all(element);
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );
       for ( int ni = 0; ni < num_nodes; ++ni ) {

--- a/src/AssembleScalarElemSolverAlgorithm.C
+++ b/src/AssembleScalarElemSolverAlgorithm.C
@@ -104,8 +104,6 @@ AssembleScalarElemSolverAlgorithm::initialize_connectivity()
 void
 AssembleScalarElemSolverAlgorithm::execute()
 {
-
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -236,8 +234,8 @@ AssembleScalarElemSolverAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * node_rels = bulk_data.begin_nodes(elem);
-      int num_nodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const * node_rels = realm_.begin_nodes_all(elem);
+      int num_nodes = realm_.num_nodes_all(elem);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );

--- a/src/AssembleScalarFluxBCSolverAlgorithm.C
+++ b/src/AssembleScalarFluxBCSolverAlgorithm.C
@@ -66,7 +66,6 @@ void
 AssembleScalarFluxBCSolverAlgorithm::execute()
 {
 
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -142,8 +141,8 @@ AssembleScalarFluxBCSolverAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = bulk_data .begin_nodes(face);
-      int num_face_nodes = bulk_data.num_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
+      int num_face_nodes = realm_.num_nodes_all(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {

--- a/src/ComputeGeometryBoundaryAlgorithm.C
+++ b/src/ComputeGeometryBoundaryAlgorithm.C
@@ -83,12 +83,12 @@ ComputeGeometryBoundaryAlgorithm::execute()
       double * areaVec = stk::mesh::field_data(*exposedAreaVec, b, k);
 
       // face node relations for nodal gather
-      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(b,k);
 
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      int num_nodes = b.num_nodes(k);
+      int num_nodes = realm_.num_nodes_all(b,k);
       for ( int ni = 0; ni < num_nodes; ++ni ) {
         stk::mesh::Entity node = face_node_rels[ni];
         double * coords = stk::mesh::field_data(*coordinates, node);

--- a/src/ComputeGeometryExtrusionBoundaryAlgorithm.C
+++ b/src/ComputeGeometryExtrusionBoundaryAlgorithm.C
@@ -142,8 +142,8 @@ ComputeGeometryExtrusionBoundaryAlgorithm::execute()
       theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
       
       // concentrate on loading up the nodal coordinates for the extruded element
-      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
       for ( int ni = 0; ni < num_nodes; ++ni ) {
 	stk::mesh::Entity node = face_node_rels[ni];
 	const double * coords = stk::mesh::field_data(*coordinates, node);
@@ -182,7 +182,7 @@ ComputeGeometryExtrusionBoundaryAlgorithm::execute()
       }
       
       // deal with edges on the exposed face... 
-      stk::mesh::Entity const* elem_node_rels = bulk_data.begin_nodes(element);
+      stk::mesh::Entity const* elem_node_rels = realm_.begin_nodes_all(element);
       
       // face edge relations; if this is 2D then the face is a edge and size is unity
       stk::mesh::Entity const* face_edge_rels = bulk_data.begin_edges(face);

--- a/src/ComputeGeometryInteriorAlgorithm.C
+++ b/src/ComputeGeometryInteriorAlgorithm.C
@@ -97,8 +97,8 @@ ComputeGeometryInteriorAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );
@@ -156,12 +156,12 @@ ComputeGeometryInteriorAlgorithm::execute()
       for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
 
         // Use node Entity because we'll need to call BulkData::identifier(.).
-        stk::mesh::Entity const * elem_node_rels = b.begin_nodes(k);
+        stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(b,k);
 
         //===============================================
         // gather nodal data; this is how we do it now..
         //===============================================
-        int num_nodes = b.num_nodes(k);
+        int num_nodes = realm_.num_nodes_all(b,k);
         for ( int ni = 0; ni < num_nodes; ++ni ) {
           stk::mesh::Entity node = elem_node_rels[ni];
           double * coords = stk::mesh::field_data(*coordinates, node);

--- a/src/ComputeHeatTransferEdgeWallAlgorithm.C
+++ b/src/ComputeHeatTransferEdgeWallAlgorithm.C
@@ -76,7 +76,6 @@ void
 ComputeHeatTransferEdgeWallAlgorithm::execute()
 {
 
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -123,7 +122,7 @@ ComputeHeatTransferEdgeWallAlgorithm::execute()
       theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
 
       // get the relations
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
 
       for ( int ip = 0; ip < num_face_nodes; ++ip ) {
 

--- a/src/ComputeHeatTransferElemWallAlgorithm.C
+++ b/src/ComputeHeatTransferElemWallAlgorithm.C
@@ -74,7 +74,6 @@ void
 ComputeHeatTransferElemWallAlgorithm::execute()
 {
 
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -160,8 +159,8 @@ ComputeHeatTransferElemWallAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
-      const int num_face_nodes = bulk_data.num_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
+      const int num_face_nodes = realm_.num_nodes_all(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -188,8 +187,8 @@ ComputeHeatTransferElemWallAlgorithm::execute()
       //==========================================
       // gather nodal data off of element
       //==========================================
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
-      int num_nodes = bulk_data.num_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
+      int num_nodes = realm_.num_nodes_all(element);
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );
       for ( int ni = 0; ni < num_nodes; ++ni ) {

--- a/src/ComputeLowReynoldsSDRWallAlgorithm.C
+++ b/src/ComputeLowReynoldsSDRWallAlgorithm.C
@@ -111,7 +111,7 @@ ComputeLowReynoldsSDRWallAlgorithm::execute()
 
     // face master element
     MasterElement *meFC = realm_.get_surface_master_element(b.topology());
-    const int nodesPerFace = b.topology().num_nodes();
+    const int nodesPerFace = meFC->nodesPerElement_;
     std::vector<int> face_node_ordinal_vec(nodesPerFace);
 
     // algorithm related; element
@@ -140,8 +140,8 @@ ComputeLowReynoldsSDRWallAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
-      int num_face_nodes = bulk_data.num_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
+      int num_face_nodes = realm_.num_nodes_all(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -162,10 +162,10 @@ ComputeLowReynoldsSDRWallAlgorithm::execute()
       // get element; its face ordinal number and populate face_node_ordinal_vec
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = bulk_data.begin_element_ordinals(face)[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinal_vec.begin());
+              realm_.side_node_ordinals_all(theElemTopo, face_ordinal, face_node_ordinal_vec);
 
       // get the relations off of element
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
 
       // loop over face nodes
       for ( int ip = 0; ip < num_face_nodes; ++ip ) {

--- a/src/ComputeMdotEdgeAlgorithm.C
+++ b/src/ComputeMdotEdgeAlgorithm.C
@@ -113,10 +113,10 @@ ComputeMdotEdgeAlgorithm::execute()
 
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
 
-      stk::mesh::Entity const * edge_node_rels = b.begin_nodes(k);
+      stk::mesh::Entity const * edge_node_rels = realm_.begin_nodes_all(b,k);
 
       // sanity check on number or nodes
-      ThrowAssert( b.num_nodes(k) == 2 );
+      ThrowAssert( realm_.num_nodes_all(b,k) == 2 );
 
       // pointer to edge area vector
       for ( int j = 0; j < nDim; ++j )

--- a/src/ComputeMdotEdgeContactAlgorithm.C
+++ b/src/ComputeMdotEdgeContactAlgorithm.C
@@ -80,8 +80,6 @@ ComputeMdotEdgeContactAlgorithm::execute()
 {
 
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
-
   const int nDim = meta_data.spatial_dimension();
 
   // extract noc
@@ -151,8 +149,8 @@ ComputeMdotEdgeContactAlgorithm::execute()
       // pointer to edge area vector
       const double *p_areaVec = &infoObject->haloEdgeAreaVec_[0];
 
-      stk::mesh::Entity const* elem_node_rels = bulk_data.begin_nodes(elem);
-      const int num_nodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const* elem_node_rels = realm_.begin_nodes_all(elem);
+      const int num_nodes = realm_.num_nodes_all(elem);
 
       // now load the elemental values for future interpolation
       for ( int ni = 0; ni < num_nodes; ++ni ) {

--- a/src/ComputeMdotEdgeOpenAlgorithm.C
+++ b/src/ComputeMdotEdgeOpenAlgorithm.C
@@ -56,7 +56,6 @@ void
 ComputeMdotEdgeOpenAlgorithm::execute()
 {
 
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -118,7 +117,7 @@ ComputeMdotEdgeOpenAlgorithm::execute()
       theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
 
       // get the relations
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
 
       for ( int ip = 0; ip < num_face_nodes; ++ip ) {
 

--- a/src/ComputeMdotElemAlgorithm.C
+++ b/src/ComputeMdotElemAlgorithm.C
@@ -182,8 +182,8 @@ ComputeMdotElemAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );
@@ -320,7 +320,7 @@ ComputeMdotElemAlgorithm::assemble_edge_mdot()
       const double *scsMdot = stk::mesh::field_data(*massFlowRate_, elem );
 
       // Use node Entity because we'll need to call BulkData::identifier(.).
-      stk::mesh::Entity const * elem_node_rels = b.begin_nodes(k);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(b,k);
 
       // iterate edges
       stk::mesh::Entity const * elem_edge_rels = b.begin_edges(k);

--- a/src/ComputeMdotElemOpenAlgorithm.C
+++ b/src/ComputeMdotElemOpenAlgorithm.C
@@ -140,7 +140,7 @@ ComputeMdotElemOpenAlgorithm::execute()
 
     // face master element
     MasterElement *meFC = realm_.get_surface_master_element(b.topology());
-    const int nodesPerFace = b.topology().num_nodes();
+    const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsBip = meFC->numIntPoints_;
     std::vector<int> face_node_ordinal_vec(nodesPerFace);
 
@@ -186,8 +186,8 @@ ComputeMdotElemOpenAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
-      int num_face_nodes = bulk_data.num_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
+      int num_face_nodes = realm_.num_nodes_all(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -218,13 +218,13 @@ ComputeMdotElemOpenAlgorithm::execute()
       // get element; its face ordinal number and populate face_node_ordinal_vec
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = bulk_data.begin_element_ordinals(face)[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinal_vec.begin());
+      realm_.side_node_ordinals_all(theElemTopo, face_ordinal, face_node_ordinal_vec);
 
       //======================================
       // gather nodal data off of element
       //======================================
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
-      int num_nodes = bulk_data.num_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
+      int num_nodes = realm_.num_nodes_all(element);
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );
       for ( int ni = 0; ni < num_nodes; ++ni ) {

--- a/src/ComputeSSTMaxLengthScaleElemAlgorithm.C
+++ b/src/ComputeSSTMaxLengthScaleElemAlgorithm.C
@@ -106,7 +106,7 @@ ComputeSSTMaxLengthScaleElemAlgorithm::execute()
       stk::mesh::Entity elem = b[k];
 
       // node relations
-      stk::mesh::Entity const * node_rels = bulk_data.begin_nodes(elem);
+      stk::mesh::Entity const * node_rels = realm_.begin_nodes_all(elem);
 
       // compute max edge length
       for ( int ip = 0; ip < numScsIp; ++ip ) {

--- a/src/ComputeTurbKineticEnergyWallFunctionAlgorithm.C
+++ b/src/ComputeTurbKineticEnergyWallFunctionAlgorithm.C
@@ -67,7 +67,6 @@ void
 ComputeTurbKineticEnergyWallFunctionAlgorithm::execute()
 {
 
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -86,7 +85,6 @@ ComputeTurbKineticEnergyWallFunctionAlgorithm::execute()
     stk::mesh::Bucket & b = **ib ;
 
     // face master element; only need the face topo
-    const int nodesPerFace = b.topology().num_nodes();
     const stk::mesh::Bucket::size_type length   = b.size();
 
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
@@ -95,7 +93,8 @@ ComputeTurbKineticEnergyWallFunctionAlgorithm::execute()
       stk::mesh::Entity face = b[k];
 
       // get relations to nodes
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
+      const int nodesPerFace = realm_.num_nodes_all(face);
 
       // pointer to face data
       const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);

--- a/src/ComputeWallFrictionVelocityAlgorithm.C
+++ b/src/ComputeWallFrictionVelocityAlgorithm.C
@@ -134,7 +134,7 @@ ComputeWallFrictionVelocityAlgorithm::execute()
 
     // face master element
     MasterElement *meFC = realm_.get_surface_master_element(b.topology());
-    const int nodesPerFace = b.topology().num_nodes();
+    const int nodesPerFace = meFC->nodesPerElement_;
     std::vector<int> face_node_ordinal_vec(nodesPerFace);
 
     // algorithm related; element
@@ -167,8 +167,8 @@ ComputeWallFrictionVelocityAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
-      int num_face_nodes = bulk_data.num_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
+      int num_face_nodes = realm_.num_nodes_all(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -200,10 +200,10 @@ ComputeWallFrictionVelocityAlgorithm::execute()
       // get element; its face ordinal number and populate face_node_ordinal_vec
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = bulk_data.begin_element_ordinals(face)[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinal_vec.begin());
+              realm_.side_node_ordinals_all(theElemTopo, face_ordinal, face_node_ordinal_vec);
 
       // get the relations off of element
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
 
       // loop over face nodes
       for ( int ip = 0; ip < num_face_nodes; ++ip ) {

--- a/src/ComputeWallModelSDRWallAlgorithm.C
+++ b/src/ComputeWallModelSDRWallAlgorithm.C
@@ -99,7 +99,7 @@ ComputeWallModelSDRWallAlgorithm::execute()
     MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
 
     // face master element
-    const int nodesPerFace = b.topology().num_nodes();
+    const int nodesPerFace = meSCS->nodesPerElement_;
     std::vector<int> face_node_ordinal_vec(nodesPerFace);
 
     const stk::mesh::Bucket::size_type length   = b.size();
@@ -112,7 +112,7 @@ ComputeWallModelSDRWallAlgorithm::execute()
       //======================================
       // gather nodal data off of face; n/a
       //======================================
-      int num_face_nodes = bulk_data.num_nodes(face);
+      int num_face_nodes = realm_.num_nodes_all(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
 
@@ -127,10 +127,10 @@ ComputeWallModelSDRWallAlgorithm::execute()
       // get element; its face ordinal number and populate face_node_ordinal_vec
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = bulk_data.begin_element_ordinals(face)[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinal_vec.begin());
+              realm_.side_node_ordinals_all(theElemTopo, face_ordinal, face_node_ordinal_vec);
 
       // get the relations off of element
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
 
       // loop over face nodes
       for ( int ip = 0; ip < num_face_nodes; ++ip ) {

--- a/src/ContactInfo.C
+++ b/src/ContactInfo.C
@@ -331,8 +331,8 @@ ContactInfo::complete_search()
       theHaloCoords = theHaloInfo->haloNodalCoords_;
 
       // now load the elemental nodal coords
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(elem);
-      int num_nodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(elem);
+      int num_nodes = realm_.num_nodes_all(elem);
 
       for ( int ni = 0; ni < num_nodes; ++ni ) {
         stk::mesh::Entity node = elem_node_rels[ni];
@@ -402,8 +402,8 @@ ContactInfo::complete_search()
       isoParCoords = infoObject->isoParCoords_;
 
       // now load the elemental nodal coords
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(elem);
-      int num_nodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(elem);
+      int num_nodes = realm_.num_nodes_all(elem);
 
       for ( int ni = 0; ni < num_nodes; ++ni ) {
         stk::mesh::Entity node = elem_node_rels[ni];
@@ -468,8 +468,8 @@ ContactInfo::find_possible_elements()
       }
 
       // extract elem_node_relations
-      stk::mesh::Entity const* elem_node_rels = bulk_data.begin_nodes(elem);
-      const int num_nodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const* elem_node_rels = realm_.begin_nodes_all(elem);
+      const int num_nodes = realm_.num_nodes_all(elem);
 
       for ( int ni = 0; ni < num_nodes; ++ni ) {
         stk::mesh::Entity node = elem_node_rels[ni];

--- a/src/ContinuityAdvElemSuppAlg.C
+++ b/src/ContinuityAdvElemSuppAlg.C
@@ -133,8 +133,8 @@ ContinuityAdvElemSuppAlg::elem_execute(
   double *p_dndx_lhs = shiftPoisson_ ? &ws_dndx_[0] : reducedSensitivities_ ? &ws_dndx_lhs_[0] : &ws_dndx_[0];
 
   // gather
-  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
-  int num_nodes = bulkData_->num_nodes(element);
+  stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(element);
+  int num_nodes = realm_.num_nodes_all(element);
 
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );

--- a/src/ContinuityMassBDF2ElemSuppAlg.C
+++ b/src/ContinuityMassBDF2ElemSuppAlg.C
@@ -110,8 +110,8 @@ ContinuityMassBDF2ElemSuppAlg::elem_execute(
   const int numScvIp = meSCV->numIntPoints_;
 
   // gather
-  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
-  int num_nodes = bulkData_->num_nodes(element);
+  stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(element);
+  int num_nodes = realm_.num_nodes_all(element);
 
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );

--- a/src/EpetraLinearSystem.C
+++ b/src/EpetraLinearSystem.C
@@ -221,7 +221,7 @@ EpetraLinearSystem::buildEdgeToNodeGraph(const stk::mesh::PartVector & parts)
     const stk::mesh::Bucket::size_type length   = b.size();
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
       const unsigned edge_offset = k;
-      stk::mesh::Entity const * const edge_nodes = b.begin_nodes(edge_offset);
+      stk::mesh::Entity const * const edge_nodes = realm_.begin_nodes_all(b,edge_offset);
 
       // figure out the global dof ids for each dof on each node
       for(int n=0; n < numNodes; ++n) {
@@ -254,10 +254,10 @@ EpetraLinearSystem::buildFaceToNodeGraph(const stk::mesh::PartVector & parts)
     const stk::mesh::Bucket::size_type length   = b.size();
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
       const unsigned face_offset = k;
-      stk::mesh::Entity const * face_nodes = b.begin_nodes(face_offset);
+      stk::mesh::Entity const * face_nodes = realm_.begin_nodes_all(b,face_offset);
 
       // figure out the global dof ids for each dof on each node
-      const int numNodes = b.num_nodes(face_offset);
+      const int numNodes = realm_.num_nodes_all(b,face_offset);
       const int numIds = numNodes * numDof_;
       gids.resize(numIds);
       for(int n=0; n < numNodes; ++n) {
@@ -290,10 +290,10 @@ EpetraLinearSystem::buildElemToNodeGraph(const stk::mesh::PartVector & parts)
     const stk::mesh::Bucket::size_type length   = b.size();
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
       const unsigned elem_offset = k;
-      stk::mesh::Entity const * elem_nodes = b.begin_nodes(elem_offset);
+      stk::mesh::Entity const * elem_nodes = realm_.begin_nodes_all(b,elem_offset);
 
       // figure out the global dof ids for each dof on each node
-      const int numNodes = b.num_nodes(elem_offset);
+      const int numNodes = realm_.num_nodes_all(b,elem_offset);
       const int numIds = numNodes * numDof_;
       gids.resize(numIds);
       for(int n=0; n < numNodes; ++n) {
@@ -332,7 +332,7 @@ EpetraLinearSystem::buildReducedElemToNodeGraph(const stk::mesh::PartVector & pa
     const stk::mesh::Bucket::size_type length   = b.size();
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
       const unsigned elem_offset = k;
-      stk::mesh::Entity const * elem_nodes = b.begin_nodes(elem_offset);
+      stk::mesh::Entity const * elem_nodes = realm_.begin_nodes_all(b,elem_offset);
 
       // figure out the global dof ids for each dof on each node
       const int numIds = 2 * numDof_;
@@ -382,10 +382,10 @@ EpetraLinearSystem::buildFaceElemToNodeGraph(const stk::mesh::PartVector & parts
 
       // get connected element
       stk::mesh::Entity element = face_elem_rels[0];
-      const stk::mesh::Entity* elem_nodes = bulk_data.begin_nodes(element);
+      const stk::mesh::Entity* elem_nodes = realm_.begin_nodes_all(element);
 
       // figure out the global dof ids for each dof on each node
-      const int numNodes = bulk_data.num_nodes(element);
+      const int numNodes = realm_.num_nodes_all(element);
       const int numIds = numNodes * numDof_;
       gids.resize(numIds);
       for(int n=0; n < numNodes; ++n) {
@@ -406,8 +406,6 @@ EpetraLinearSystem::buildEdgeHaloNodeGraph(
 {
 
   beginLinearSystemConstruction();
-
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
 
   int err_code(0);
 
@@ -431,8 +429,8 @@ EpetraLinearSystem::buildEdgeHaloNodeGraph(
 
       // relations
 
-      stk::mesh::Entity const* elem_nodes = bulk_data.begin_nodes(elem);
-      const int numNodes = bulk_data.num_nodes(elem);
+      stk::mesh::Entity const* elem_nodes = realm_.begin_nodes_all(elem);
+      const int numNodes = realm_.num_nodes_all(elem);
 
       const int numIds = (numNodes+1) * numDof_;
       std::vector<int> gids(numIds);

--- a/src/EquationSystems.C
+++ b/src/EquationSystems.C
@@ -17,6 +17,8 @@
 #include <Simulation.h>
 #include <SolutionOptions.h>
 
+#include <element_promotion/PromoteElement.h> // for promoted_part
+
 // all concrete EquationSystem's
 #include <EnthalpyEquationSystem.h>
 #include <HeatCondEquationSystem.h>
@@ -27,6 +29,8 @@
 #include <TurbKineticEnergyEquationSystem.h>
 #include <pmr/RadiativeTransportEquationSystem.h>
 #include <mesh_motion/MeshDisplacementEquationSystem.h>
+
+
 
 #include <vector>
 
@@ -316,7 +320,7 @@ EquationSystems::register_wall_bc(
     // found the part
     const std::vector<stk::mesh::Part*> & mesh_parts = targetPart->subsets();
     for( std::vector<stk::mesh::Part*>::const_iterator i = mesh_parts.begin();
-         i != mesh_parts.end(); ++i )
+        i != mesh_parts.end(); ++i )
     {
       stk::mesh::Part * const part = *i ;
       const stk::topology the_topo = part->topology();
@@ -329,6 +333,13 @@ EquationSystems::register_wall_bc(
         EquationSystemVector::iterator ii;
         for( ii=equationSystemVector_.begin(); ii!=equationSystemVector_.end(); ++ii )
           (*ii)->register_wall_bc(part, the_topo, wallBCData);
+      }
+
+      if (realm_.doPromotion_) {
+        auto* promotedPart = promoted_part(*part);
+        EquationSystemVector::iterator ii;
+        for( ii=equationSystemVector_.begin(); ii!=equationSystemVector_.end(); ++ii )
+          (*ii)->register_wall_bc(promotedPart, part->topology(), wallBCData);
       }
     }
   }
@@ -366,6 +377,13 @@ EquationSystems::register_inflow_bc(
         for( ii=equationSystemVector_.begin(); ii!=equationSystemVector_.end(); ++ii )       
           (*ii)->register_inflow_bc(part, the_topo, inflowBCData);
       }
+
+      if (realm_.doPromotion_) {
+        auto* promotedPart = promoted_part(*part);
+        EquationSystemVector::iterator ii;
+        for( ii=equationSystemVector_.begin(); ii!=equationSystemVector_.end(); ++ii )
+          (*ii)->register_inflow_bc(promotedPart, part->topology(), inflowBCData);
+      }
     }
   }
 }
@@ -400,6 +418,13 @@ EquationSystems::register_open_bc(
         EquationSystemVector::iterator ii;
         for( ii=equationSystemVector_.begin(); ii!=equationSystemVector_.end(); ++ii )
           (*ii)->register_open_bc(part, the_topo, openBCData);
+      }
+
+      if (realm_.doPromotion_) {
+        auto* promotedPart = promoted_part(*part);
+        EquationSystemVector::iterator ii;
+        for( ii=equationSystemVector_.begin(); ii!=equationSystemVector_.end(); ++ii )
+          (*ii)->register_open_bc(promotedPart, part->topology(), openBCData);
       }
     }
   }

--- a/src/ExtrusionMeshDistanceBoundaryAlgorithm.C
+++ b/src/ExtrusionMeshDistanceBoundaryAlgorithm.C
@@ -131,12 +131,12 @@ ExtrusionMeshDistanceBoundaryAlgorithm::execute()
       double * areaVec = stk::mesh::field_data(*exposedAreaVec, b, k);
 
       // face node relations for nodal gather
-      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(b,k);
 
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      int num_nodes = b.num_nodes(k);
+      int num_nodes = realm_.num_nodes_all(b,k);
       for ( int ni = 0; ni < num_nodes; ++ni ) {
         stk::mesh::Entity node = face_node_rels[ni];
         double * coords = stk::mesh::field_data(*coordinates, node);
@@ -217,9 +217,6 @@ ExtrusionMeshDistanceBoundaryAlgorithm::execute()
         ib != face_buckets.end() ; ++ib ) {
     stk::mesh::Bucket & b = **ib ;
 
-    // size some things that are useful
-    const int num_face_nodes = b.topology().num_nodes();
-
     const stk::mesh::Bucket::size_type length   = b.size();
 
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
@@ -231,7 +228,9 @@ ExtrusionMeshDistanceBoundaryAlgorithm::execute()
       const double * areaVec = stk::mesh::field_data(*exposedAreaVec, face);
 
       // face node relations for nodal gather
-      stk::mesh::Entity const* face_node_rels = bulk_data.begin_nodes(face);
+      stk::mesh::Entity const* face_node_rels = realm_.begin_nodes_all(face);
+      // size some things that are useful
+      const int num_face_nodes = realm_.num_nodes_all(face);
 
       // one to one mapping between ips and nodes
       for ( int ip = 0; ip < num_face_nodes; ++ip ) {

--- a/src/HeatCondEquationSystem.C
+++ b/src/HeatCondEquationSystem.C
@@ -54,8 +54,11 @@
 
 // user functions
 #include <user_functions/SteadyThermalContactAuxFunction.h>
+#include <user_functions/SteadyThermalContact3DAuxFunction.h>
 #include <user_functions/SteadyThermalContactSrcNodeSuppAlg.h>
+#include <user_functions/SteadyThermalContact3DSrcNodeSuppAlg.h>
 #include <user_functions/SteadyThermalContactSrcElemSuppAlg.h>
+#include <user_functions/SteadyThermalContact3DSrcElemSuppAlg.h>
 
 // stk_util
 #include <stk_util/parallel/Parallel.hpp>
@@ -350,8 +353,14 @@ HeatCondEquationSystem::register_interior_algorithm(
             = new SteadyThermalContactSrcNodeSuppAlg(realm_);
           theAlg->supplementalAlg_.push_back(theSrc);
         }
+        else if (sourceName == "steady_3d_thermal" ) {
+          SteadyThermalContact3DSrcNodeSuppAlg *theSrc
+            = new SteadyThermalContact3DSrcNodeSuppAlg(realm_);
+          theAlg->supplementalAlg_.push_back(theSrc);
+        }
         else {
-          throw std::runtime_error("HeatCondEquationSystem::only steady_2d_thermal src term is supported");
+          throw std::runtime_error(
+            "HeatCondEquationSystem::only steady_2d_thermal/steady3d_thermal src term is supported");
         }
       }
     }
@@ -382,8 +391,14 @@ HeatCondEquationSystem::register_interior_algorithm(
             = new SteadyThermalContactSrcElemSuppAlg(realm_);
           theAlg->supplementalAlg_.push_back(theSrc);
         }
+        else if (sourceName == "steady_3d_thermal" ) {
+          SteadyThermalContact3DSrcElemSuppAlg *theSrc
+            = new SteadyThermalContact3DSrcElemSuppAlg(realm_);
+          theAlg->supplementalAlg_.push_back(theSrc);
+        }
         else {
-          throw std::runtime_error("HeatCondEquationSystem::only steady_2d_thermal element src term is supported");
+          throw std::runtime_error(
+            "HeatCondEquationSystem::only steady_2d_thermal/steady3d_thermal  element src term is supported");
         }
       }
     }
@@ -478,8 +493,11 @@ HeatCondEquationSystem::register_wall_bc(
       if ( fcnName == "steady_2d_thermal" ) {
         theAuxFunc = new SteadyThermalContactAuxFunction();
       }
+      else if ( fcnName == "steady_3d_thermal" ) {
+        theAuxFunc = new SteadyThermalContact3DAuxFunction();
+      }
       else {
-        throw std::runtime_error("Only steady_2d_thermal user functions supported");
+        throw std::runtime_error("Only steady_2d_thermal/steady_3d_thermal user functions supported");
       }
     }
     
@@ -997,8 +1015,13 @@ HeatCondEquationSystem::register_initial_condition_fcn(
       // create the function
       theAuxFunc = new SteadyThermalContactAuxFunction();      
     }
+    else if ( fcnName == "steady_3d_thermal" ) {
+      theAuxFunc = new SteadyThermalContact3DAuxFunction();
+    }
     else {
-      throw std::runtime_error("HeatCondEquationSystem::register_initial_condition_fcn: steady_2d_thermal only supported");
+      throw std::runtime_error(
+        "HeatCondEquationSystem::register_initial_condition_fcn: "
+        "steady_2d_thermal/steady_3d_thermal only supported");
     }
     
     // create the algorithm

--- a/src/LimiterErrorIndicatorElemAlgorithm.C
+++ b/src/LimiterErrorIndicatorElemAlgorithm.C
@@ -103,8 +103,8 @@ LimiterErrorIndicatorElemAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );

--- a/src/MaterialPropertys.C
+++ b/src/MaterialPropertys.C
@@ -38,7 +38,8 @@ namespace nalu{
 //--------------------------------------------------------------------------
 MaterialPropertys::MaterialPropertys(Realm& realm)
   : realm_(realm),
-    propertyTableName_("na")
+    propertyTableName_("na"),
+    promotionTag_("_promoted")
 {
   // nothing to do
 }
@@ -85,6 +86,18 @@ MaterialPropertys::load(const YAML::Node & node)
       }
     }
     
+    // add node parts for promotion
+    if (realm_.doPromotion_) {
+      baseTargetNames_ = targetNames_;
+      promotedTargetNames_ = targetNames_;
+      for (auto& targetName : promotedTargetNames_) {
+        targetName += promotionTag_;
+      }
+      targetNames_.insert(
+        targetNames_.end(),promotedTargetNames_.begin(), promotedTargetNames_.end()
+      );
+    }
+
     // has a table?
     if ( (*y_material_propertys).FindValue("table_file_name")) {
       (*y_material_propertys)["table_file_name"] >> propertyTableName_;

--- a/src/MomentumAdvDiffElemSuppAlg.C
+++ b/src/MomentumAdvDiffElemSuppAlg.C
@@ -105,8 +105,8 @@ MomentumAdvDiffElemSuppAlg::elem_execute(
   const int *lrscv = meSCS->adjacentNodes();    
   
   // gather
-  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
-  int num_nodes = bulkData_->num_nodes(element);
+  stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(element);
+  int num_nodes = realm_.num_nodes_all(element);
 
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );

--- a/src/MomentumBuoyancySrcElemSuppAlg.C
+++ b/src/MomentumBuoyancySrcElemSuppAlg.C
@@ -104,8 +104,8 @@ MomentumBuoyancySrcElemSuppAlg::elem_execute(
   const int numScvIp = meSCV->numIntPoints_;
 
   // gather
-  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
-  int num_nodes = bulkData_->num_nodes(element);
+  stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(element);
+  int num_nodes = realm_.num_nodes_all(element);
 
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );

--- a/src/MomentumMassBDF2ElemSuppAlg.C
+++ b/src/MomentumMassBDF2ElemSuppAlg.C
@@ -127,8 +127,8 @@ MomentumMassBDF2ElemSuppAlg::elem_execute(
   const int numScvIp = meSCV->numIntPoints_;
 
   // gather
-  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
-  int num_nodes = bulkData_->num_nodes(element);
+  stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(element);
+  int num_nodes = realm_.num_nodes_all(element);
 
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );

--- a/src/MomentumMassBackwardEulerElemSuppAlg.C
+++ b/src/MomentumMassBackwardEulerElemSuppAlg.C
@@ -114,8 +114,8 @@ MomentumMassBackwardEulerElemSuppAlg::elem_execute(
   const int numScvIp = meSCV->numIntPoints_;
 
   // gather
-  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
-  int num_nodes = bulkData_->num_nodes(element);
+  stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(element);
+  int num_nodes = realm_.num_nodes_all(element);
 
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );

--- a/src/MomentumNSOElemSuppAlg.C
+++ b/src/MomentumNSOElemSuppAlg.C
@@ -157,8 +157,8 @@ MomentumNSOElemSuppAlg::elem_execute(
   const int *lrscv = meSCS->adjacentNodes();    
   
   // gather
-  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
-  int num_nodes = bulkData_->num_nodes(element);
+  stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(element);
+  int num_nodes = realm_.num_nodes_all(element);
 
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );

--- a/src/NonConformalInfo.C
+++ b/src/NonConformalInfo.C
@@ -221,8 +221,8 @@ NonConformalInfo::construct_dgInfo_state()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
-      const int num_face_nodes = bulk_data.num_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
+      const int num_face_nodes = realm_.num_nodes_all(face);
       
       // sanity check on num nodes (low order, P=1, check)
       ThrowAssert( num_face_nodes == numIntPoints ); ThrowAssert( num_face_nodes == nodesPerFace );
@@ -508,8 +508,8 @@ NonConformalInfo::find_possible_face_elements()
       }
 
       // extract elem_node_relations
-      stk::mesh::Entity const* face_node_rels = bulk_data.begin_nodes(face);
-      const int num_nodes = bulk_data.num_nodes(face);
+      stk::mesh::Entity const* face_node_rels = realm_.begin_nodes_all(face);
+      const int num_nodes = realm_.num_nodes_all(face);
 
       for ( int ni = 0; ni < num_nodes; ++ni ) {
         stk::mesh::Entity node = face_node_rels[ni];

--- a/src/PstabErrorIndicatorElemAlgorithm.C
+++ b/src/PstabErrorIndicatorElemAlgorithm.C
@@ -133,8 +133,8 @@ PstabErrorIndicatorElemAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );

--- a/src/ScalarMassBDF2ElemSuppAlg.C
+++ b/src/ScalarMassBDF2ElemSuppAlg.C
@@ -118,8 +118,8 @@ ScalarMassBDF2ElemSuppAlg::elem_execute(
   const int numScvIp = meSCV->numIntPoints_;
 
   // gather
-  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
-  int num_nodes = bulkData_->num_nodes(element);
+  stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(element);
+  int num_nodes = realm_.num_nodes_all(element);
 
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );

--- a/src/ScalarNSOElemSuppAlg.C
+++ b/src/ScalarNSOElemSuppAlg.C
@@ -149,8 +149,8 @@ ScalarNSOElemSuppAlg::elem_execute(
   const int *lrscv = meSCS->adjacentNodes();    
   
   // gather
-  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
-  int num_nodes = bulkData_->num_nodes(element);
+  stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(element);
+  int num_nodes = realm_.num_nodes_all(element);
 
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );

--- a/src/ShearStressTransportEquationSystem.C
+++ b/src/ShearStressTransportEquationSystem.C
@@ -418,7 +418,7 @@ ShearStressTransportEquationSystem::clip_min_distance_to_wall()
      MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
 
      // face master element
-     const int nodesPerFace = b.topology().num_nodes();
+     const int nodesPerFace = meSCS->nodesPerElement_;
      std::vector<int> face_node_ordinal_vec(nodesPerFace);
 
      const stk::mesh::Bucket::size_type length   = b.size();
@@ -427,7 +427,7 @@ ShearStressTransportEquationSystem::clip_min_distance_to_wall()
 
        // get face
        stk::mesh::Entity face = b[k];
-       int num_face_nodes = bulk_data.num_nodes(face);
+       int num_face_nodes = realm_.num_nodes_all(face);
 
        // pointer to face data
        const double * areaVec = stk::mesh::field_data(*exposedAreaVec, face);
@@ -439,10 +439,10 @@ ShearStressTransportEquationSystem::clip_min_distance_to_wall()
        // get element; its face ordinal number and populate face_node_ordinal_vec
        stk::mesh::Entity element = face_elem_rels[0];
        const int face_ordinal = bulk_data.begin_element_ordinals(face)[0];
-       theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinal_vec.begin());
+               realm_.side_node_ordinals_all(theElemTopo, face_ordinal, face_node_ordinal_vec);
 
        // get the relations off of element
-       stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
+       stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
 
        // loop over face nodes
        for ( int ip = 0; ip < num_face_nodes; ++ip ) {

--- a/src/SimpleErrorIndicatorElemAlgorithm.C
+++ b/src/SimpleErrorIndicatorElemAlgorithm.C
@@ -110,8 +110,8 @@ SimpleErrorIndicatorElemAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );

--- a/src/SimpleErrorIndicatorScalarElemAlgorithm.C
+++ b/src/SimpleErrorIndicatorScalarElemAlgorithm.C
@@ -116,8 +116,8 @@ SimpleErrorIndicatorScalarElemAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );

--- a/src/SolutionNormPostProcessing.C
+++ b/src/SolutionNormPostProcessing.C
@@ -14,6 +14,7 @@
 
 // the factory of aux functions
 #include <user_functions/SteadyThermalContactAuxFunction.h>
+#include <user_functions/SteadyThermalContact3DAuxFunction.h>
 #include <user_functions/SteadyTaylorVortexVelocityAuxFunction.h>
 #include <user_functions/SteadyTaylorVortexGradPressureAuxFunction.h>
 
@@ -204,6 +205,9 @@ SolutionNormPostProcessing::analytical_function_factory(
   // switch on the name found...
   if ( functionName == "steady_2d_thermal" ) {
     theAuxFunc = new SteadyThermalContactAuxFunction();
+  }
+  else if ( functionName == "steady_3d_thermal" ) {
+    theAuxFunc = new SteadyThermalContact3DAuxFunction();
   }
   else if ( functionName == "SteadyTaylorVortexVelocity" ) {
     theAuxFunc = new SteadyTaylorVortexVelocityAuxFunction(0,realm_.meta_data().spatial_dimension());

--- a/src/SurfaceForceAndMomentAlgorithm.C
+++ b/src/SurfaceForceAndMomentAlgorithm.C
@@ -217,7 +217,7 @@ SurfaceForceAndMomentAlgorithm::execute()
       stk::mesh::Entity face = b[k];
 
       // face node relations
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
 
       //======================================
       // gather nodal data off of face
@@ -240,10 +240,10 @@ SurfaceForceAndMomentAlgorithm::execute()
       // get element; its face ordinal number and populate face_node_ordinal_vec
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = bulk_data.begin_element_ordinals(face)[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinal_vec.begin());
+      realm_.side_node_ordinals_all(theElemTopo, face_ordinal, face_node_ordinal_vec);
 
       // get the relations off of element
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
 
       for ( int ip = 0; ip < nodesPerFace; ++ip ) {
 
@@ -406,7 +406,6 @@ SurfaceForceAndMomentAlgorithm::pre_work()
 {
 
   // common
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   const int nDim = meta_data.spatial_dimension();
 
@@ -436,7 +435,7 @@ SurfaceForceAndMomentAlgorithm::pre_work()
       stk::mesh::Entity face = b[k];
 
       // face node relations
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
 
       // pointer to face data
       const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);

--- a/src/SurfaceForceAndMomentWallFunctionAlgorithm.C
+++ b/src/SurfaceForceAndMomentWallFunctionAlgorithm.C
@@ -135,7 +135,6 @@ SurfaceForceAndMomentWallFunctionAlgorithm::execute()
   if ( !processMe )
     return;
 
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -234,7 +233,7 @@ SurfaceForceAndMomentWallFunctionAlgorithm::execute()
       stk::mesh::Entity face = b[k];
 
       // face node relations
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
 
       //======================================
       // gather nodal data off of face
@@ -416,7 +415,6 @@ SurfaceForceAndMomentWallFunctionAlgorithm::pre_work()
 {
 
   // common
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   const int nDim = meta_data.spatial_dimension();
 
@@ -446,7 +444,7 @@ SurfaceForceAndMomentWallFunctionAlgorithm::pre_work()
       stk::mesh::Entity face = b[k];
 
       // face node relations
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
 
       // pointer to face data
       const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -425,7 +425,7 @@ TpetraLinearSystem::buildEdgeToNodeGraph(const stk::mesh::PartVector & parts)
     const stk::mesh::Bucket & b = **ib ;
     const stk::mesh::Bucket::size_type length   = b.size();
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
-      stk::mesh::Entity const * edge_nodes = b.begin_nodes(k);
+      stk::mesh::Entity const * edge_nodes = realm_.begin_nodes_all(b,k);
 
       // figure out the global dof ids for each dof on each node
       for(size_t n=0; n < numNodes; ++n) {
@@ -454,10 +454,10 @@ TpetraLinearSystem::buildFaceToNodeGraph(const stk::mesh::PartVector & parts)
     const stk::mesh::Bucket & b = **ib ;
     const stk::mesh::Bucket::size_type length   = b.size();
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
-      stk::mesh::Entity const * face_nodes = b.begin_nodes(k);
+      stk::mesh::Entity const * face_nodes = realm_.begin_nodes_all(b,k);
 
       // figure out the global dof ids for each dof on each node
-      const size_t numNodes = b.num_nodes(k);
+      const size_t numNodes = realm_.num_nodes_all(b,k);
       entities.resize(numNodes);
       for(size_t n=0; n < numNodes; ++n) {
         entities[n] = face_nodes[n];
@@ -485,9 +485,9 @@ TpetraLinearSystem::buildElemToNodeGraph(const stk::mesh::PartVector & parts)
     const stk::mesh::Bucket & b = **ib ;
     const stk::mesh::Bucket::size_type length   = b.size();
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
-      stk::mesh::Entity const * elem_nodes = b.begin_nodes(k);
+      stk::mesh::Entity const * elem_nodes = realm_.begin_nodes_all(b,k);
       // figure out the global dof ids for each dof on each node
-      const size_t numNodes = b.num_nodes(k);
+      const size_t numNodes = realm_.num_nodes_all(b,k);
       entities.resize(numNodes);
       for(size_t n=0; n < numNodes; ++n) {
         entities[n] = elem_nodes[n];
@@ -522,7 +522,7 @@ TpetraLinearSystem::buildReducedElemToNodeGraph(const stk::mesh::PartVector & pa
 
     const stk::mesh::Bucket::size_type length   = b.size();
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
-      stk::mesh::Entity const * elem_nodes = b.begin_nodes(k);
+      stk::mesh::Entity const * elem_nodes = realm_.begin_nodes_all(b,k);
 
       // figure out the global dof ids for each dof on each node
       const size_t numNodes = 2;
@@ -564,10 +564,10 @@ TpetraLinearSystem::buildFaceElemToNodeGraph(const stk::mesh::PartVector & parts
 
       // get connected element and nodal relations
       stk::mesh::Entity element = face_elem_rels[0];
-      const stk::mesh::Entity* elem_nodes = bulkData.begin_nodes(element);
+      const stk::mesh::Entity* elem_nodes = realm_.begin_nodes_all(element);
 
       // figure out the global dof ids for each dof on each node
-      const size_t numNodes = bulkData.num_nodes(element);
+      const size_t numNodes = realm_.num_nodes_all(element);
       entities.resize(numNodes);
       for(size_t n=0; n < numNodes; ++n) {
         entities[n] = elem_nodes[n];
@@ -581,7 +581,6 @@ void
 TpetraLinearSystem::buildEdgeHaloNodeGraph(
   const stk::mesh::PartVector &/*parts*/)
 {
-  stk::mesh::BulkData & bulkData = realm_.bulk_data();
   beginLinearSystemConstruction();
 
   std::vector<stk::mesh::Entity> entities;
@@ -605,8 +604,8 @@ TpetraLinearSystem::buildEdgeHaloNodeGraph(
       stk::mesh::Entity node = infoObject->faceNode_;
 
       // relations
-      stk::mesh::Entity const* elem_nodes = bulkData.begin_nodes(elem);
-      const size_t numNodes = bulkData.num_nodes(elem);
+      stk::mesh::Entity const* elem_nodes = realm_.begin_nodes_all(elem);
+      const size_t numNodes = realm_.num_nodes_all(elem);
       const size_t numEntities = numNodes+1;
       entities.resize(numEntities);
 
@@ -623,7 +622,6 @@ void
 TpetraLinearSystem::buildNonConformalNodeGraph(
   const stk::mesh::PartVector &/*parts*/)
 {
-  stk::mesh::BulkData & bulkData = realm_.bulk_data();
   beginLinearSystemConstruction();
 
   std::vector<stk::mesh::Entity> entities;
@@ -651,10 +649,10 @@ TpetraLinearSystem::buildNonConformalNodeGraph(
         stk::mesh::Entity opposingElement = dgInfo->opposingElement_;
         
         // node relations; current and opposing
-        stk::mesh::Entity const* current_elem_node_rels = bulkData.begin_nodes(currentElement);
-        const int current_num_elem_nodes = bulkData.num_nodes(currentElement);
-        stk::mesh::Entity const* opposing_elem_node_rels = bulkData.begin_nodes(opposingElement);
-        const int opposing_num_elem_nodes = bulkData.num_nodes(opposingElement);
+        stk::mesh::Entity const* current_elem_node_rels = realm_.begin_nodes_all(currentElement);
+        const int current_num_elem_nodes = realm_.num_nodes_all(currentElement);
+        stk::mesh::Entity const* opposing_elem_node_rels = realm_.begin_nodes_all(opposingElement);
+        const int opposing_num_elem_nodes = realm_.num_nodes_all(opposingElement);
         
         // resize based on both current and opposing face node size
         entities.resize(current_num_elem_nodes+opposing_num_elem_nodes);
@@ -706,8 +704,8 @@ TpetraLinearSystem::buildOversetNodeGraph(
       continue;
 
     // relations
-    stk::mesh::Entity const* elem_nodes = bulkData.begin_nodes(owningElement);
-    const size_t numNodes = bulkData.num_nodes(owningElement);
+    stk::mesh::Entity const* elem_nodes = realm_.begin_nodes_all(owningElement);
+    const size_t numNodes = realm_.num_nodes_all(owningElement);
     const size_t numEntities = numNodes+1;
     entities.resize(numEntities);
     

--- a/src/TurbKineticEnergyKsgsBuoyantElemSuppAlg.C
+++ b/src/TurbKineticEnergyKsgsBuoyantElemSuppAlg.C
@@ -113,8 +113,8 @@ TurbKineticEnergyKsgsBuoyantElemSuppAlg::elem_execute(
   const int numScvIp = meSCV->numIntPoints_;
 
   // gather
-  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
-  int num_nodes = bulkData_->num_nodes(element);
+  stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(element);
+  int num_nodes = realm_.num_nodes_all(element);
 
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );

--- a/src/element_promotion/ElementDescription.C
+++ b/src/element_promotion/ElementDescription.C
@@ -1,0 +1,636 @@
+#include <element_promotion/ElementDescription.h>
+
+#include <element_promotion/FaceOperations.h>
+#include <element_promotion/LagrangeBasis.h>
+#include <element_promotion/QuadratureRule.h>
+#include <element_promotion/TensorProductQuadratureRule.h>
+#include <NaluEnv.h>
+#include <nalu_make_unique.h>
+
+#include <stk_util/environment/ReportHandler.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+
+namespace sierra {
+namespace nalu {
+
+  //TODO(rcknaus): ElementDescription has become pretty bulky
+  // separate out the CVFEM-specific stuff
+
+std::unique_ptr<ElementDescription>
+ElementDescription::create(int dimension,int order)
+{
+  bool symmWeights = false;
+
+  if (dimension == 2 && order == 2) {
+    std::vector<double> in_nodeLocs = { -1.0, 0.0, +1.0 };
+    std::vector<double> in_scsLoc = { -std::sqrt(3.0)/3.0, std::sqrt(3.0)/3.0 };
+    return make_unique<QuadMElementDescription>(in_nodeLocs,in_scsLoc);
+  }
+  if (dimension == 2 && order == 3 && symmWeights) {
+    // symmetric mass matrix
+    // I can't find a symmetric mass matrix for P > 3
+    double xgll    = 0.4487053820572093009546164613323186035;
+    double scsDist = 0.8347278713337825805263131558586123084;
+    std::vector<double> in_nodeLocs = { -1.0, -xgll, +xgll, +1.0 };
+    std::vector<double> in_scsLoc = { -scsDist, 0.0, scsDist };
+
+    return make_unique<QuadMElementDescription>(in_nodeLocs,in_scsLoc);
+  }
+
+  if (dimension == 2 && order >= 3) {
+     std::vector<double> lobattoNodes;
+     std::vector<double> legendreSCSLocations;
+     std::tie(lobattoNodes,std::ignore) = gauss_lobatto_legendre_rule(order+1);
+     std::tie(legendreSCSLocations,std::ignore) = gauss_legendre_rule(order);
+
+     return make_unique<QuadMElementDescription>(lobattoNodes,legendreSCSLocations);
+  }
+
+  if (dimension == 3 && order == 2) {
+    double scsDist = std::sqrt(3.0)/3.0;
+    std::vector<double> in_nodeLocs = {-1.0, 0.0, +1.0};
+    std::vector<double> in_scsLoc = { -scsDist, +scsDist };
+    return make_unique<HexMElementDescription>(in_nodeLocs, in_scsLoc);
+  }
+
+  if (dimension == 3 && order == 3 && symmWeights) {
+    double xgll    = 0.4487053820572093009546164613323186035;
+    double scsDist = 0.8347278713337825805263131558586123084;
+    std::vector<double> in_nodeLocs = { -1.0, -xgll, +xgll, +1.0 };
+    std::vector<double> in_scsLoc = { -scsDist, 0.0, scsDist };
+    return make_unique<HexMElementDescription>(in_nodeLocs, in_scsLoc);
+  }
+
+  if (dimension == 3 && order >= 3) {
+     std::vector<double> lobattoNodes;
+     std::vector<double> legendreSCSLocations;
+     std::tie(lobattoNodes,std::ignore) = gauss_lobatto_legendre_rule(order+1);
+     std::tie(legendreSCSLocations,std::ignore) = gauss_legendre_rule(order);
+
+     return make_unique<HexMElementDescription>(lobattoNodes,legendreSCSLocations);
+  }
+
+  throw std::runtime_error("Element type not implemented");
+  return nullptr;
+}
+
+QuadMElementDescription::QuadMElementDescription(
+  std::vector<double> in_nodeLocs, std::vector<double> in_scsLoc)
+  : ElementDescription()
+{
+  nodeLocs = in_nodeLocs;
+  scsLoc = in_scsLoc;
+  ThrowRequire(nodeLocs.size()-1 == scsLoc.size());
+
+  polyOrder = nodeLocs.size()-1;
+  nodes1D = nodeLocs.size();
+  nodesPerElement = nodes1D*nodes1D;
+  dimension = 2;
+  numQuad = (polyOrder % 2 == 0) ? polyOrder/2 + 1 : (polyOrder+1)/2;
+  useGLLGLL = false;
+
+  set_node_connectivity();
+  set_subelement_connectivity();
+
+  quadrature = make_unique<TensorProductQuadratureRule>("GaussLegendre", numQuad, scsLoc);
+  basis = make_unique<LagrangeBasis>(inverseNodeMap, nodeLocs);
+  basisBoundary = make_unique<LagrangeBasis>(inverseNodeMapBC,nodeLocs);
+}
+//--------------------------------------------------------------------------
+void
+QuadMElementDescription::set_node_connectivity()
+{
+  unsigned baseNodesPerElement = 4;
+  unsigned nodeNumber = baseNodesPerElement;
+
+  nodeMap.resize(nodes1D*nodes1D);
+  auto nmap = [&] (unsigned i, unsigned j) -> unsigned&
+  {
+    return (nodeMap[i+nodes1D*j]);
+  };
+
+  struct EdgeInfo
+  {
+    int direction;
+    int xloc;
+    int yloc;
+  };
+
+  std::vector<std::pair<std::vector<size_t>, EdgeInfo>> baseEdgeInfo = {
+      {{0,1}, {+1, 0,0}},
+      {{1,2}, {+2, 1,0}},
+      {{2,3}, {-1, 1,1}},
+      {{3,0}, {-2, 0,1}}
+  };
+
+  int faceMap[4] = {0,1,2,3};
+
+  unsigned jmax = nodes1D-1;
+  std::vector<size_t> baseFaceNodes = {0, 1, 2, 3};
+
+  nmap(0,0)       = 0;
+  nmap(jmax,0)    = 1;
+  nmap(jmax,jmax) = 2;
+  nmap(0,jmax)    = 3;
+
+  faceNodeMap.resize(4);
+  unsigned faceOrdinal = 0;
+  for (auto& baseEdge : baseEdgeInfo) {
+    auto direction = baseEdge.second.direction;
+    std::vector<size_t> nodesToAdd(nodes1D-2);
+    for (unsigned j =0; j < nodes1D-2; ++j) {
+      nodesToAdd[j] = nodeNumber;
+      ++nodeNumber;
+    }
+    edgeNodeConnectivities.insert({nodesToAdd,baseEdge.first});
+
+    auto reorderedNodes = nodesToAdd;
+    if (direction < 0) {
+      std::reverse(reorderedNodes.begin(), reorderedNodes.end());
+    }
+
+    unsigned il = (baseEdge.second.xloc == 1) ? jmax : 0;
+    unsigned jl = (baseEdge.second.yloc == 1) ? jmax : 0;
+
+    if (std::abs(direction) == 1) {
+      for (unsigned j = 1; j < polyOrder; ++j) {
+        nmap(j,jl) = reorderedNodes.at(j-1);
+      }
+    }
+    else {
+      for (unsigned j = 1; j < polyOrder; ++j) {
+        nmap(il,j) = reorderedNodes.at(j-1);
+      }
+    }
+
+    std::vector<std::vector<double>> locs(polyOrder-1);
+    for (unsigned i = 0; i < polyOrder-1; ++i) {
+      locs[i].push_back(nodeLocs[1+i]);
+    }
+    locationsForNewNodes.insert({nodesToAdd,locs});
+
+    std::vector<size_t> faceNodes(nodes1D);
+     if (std::abs(direction) == 1) {
+       for (unsigned j = 0; j < nodes1D; ++j) {
+         faceNodes[j] = nmap(j,jl);
+       }
+     }
+
+     if (std::abs(direction) == 2) {
+       for (unsigned j = 0; j < nodes1D; ++j) {
+         faceNodes[j] = nmap(il,j);
+       }
+     }
+
+     faceNodeMap[faceMap[faceOrdinal]] = faceNodes;
+     ++faceOrdinal;
+  }
+
+  // reverse edges oriented in the negative direction in isoparametric space
+  std::reverse(faceNodeMap[faceMap[2]].begin(), faceNodeMap[faceMap[2]].end());
+  std::reverse(faceNodeMap[faceMap[3]].begin(), faceNodeMap[faceMap[3]].end());
+
+  unsigned faceNodeNumber = nodeNumber;
+  unsigned nodesLeft = (nodes1D*nodes1D) - faceNodeNumber;
+  std::vector<size_t> faceNodesToAdd(nodesLeft);
+  for (unsigned j = 0; j < nodesLeft;++j) {
+    faceNodesToAdd[j] = faceNodeNumber;
+    ++faceNodeNumber;
+  }
+  faceNodeConnectivities.insert({faceNodesToAdd,baseFaceNodes});
+
+  for (unsigned j = 1; j < polyOrder; ++j) {
+    for (unsigned i = 1; i < polyOrder; ++i) {
+      nmap(i,j) = faceNodesToAdd.at((i-1)+(polyOrder-1)*(j-1));
+    }
+  }
+
+  std::vector<std::vector<double>> locs((polyOrder-1)*(polyOrder-1));
+  for (unsigned j = 0; j < polyOrder-1; ++j) {
+    for (unsigned i = 0; i < polyOrder-1; ++i) {
+      locs[i+(polyOrder-1)*j] = {nodeLocs[i+1],nodeLocs[j+1]};
+    }
+  }
+  locationsForNewNodes.insert({faceNodesToAdd, locs});
+
+  for (const auto& edgeNode : edgeNodeConnectivities) {
+    addedConnectivities.insert(edgeNode);
+  }
+
+  for (const auto& faceNode : faceNodeConnectivities) {
+    addedConnectivities.insert(faceNode);
+  }
+
+  nodeMapBC.resize(nodes1D);
+  nodeMapBC[0] = 0;
+  nodeMapBC[nodes1D-1] = 1;
+
+  nodeNumber = 2;
+  for (unsigned j = 1; j < polyOrder; ++j) {
+    nodeMapBC[j] = nodeNumber;
+    ++nodeNumber;
+  }
+
+  //inverse maps
+  inverseNodeMap.resize(nodes1D*nodes1D);
+  for (unsigned i = 0; i < nodes1D; ++i) {
+    for (unsigned j = 0; j < nodes1D; ++j) {
+      inverseNodeMap[tensor_product_node_map(i,j)] = {i, j};
+    }
+  }
+
+  inverseNodeMapBC.resize(nodes1D);
+  for (unsigned j = 0; j < nodes1D; ++j) {
+    inverseNodeMapBC[tensor_product_node_map(j)] = { j };
+  }
+
+  sideOrdinalMap.resize(4);
+  for (unsigned face_ordinal = 0; face_ordinal < 4; ++face_ordinal) {
+    sideOrdinalMap[face_ordinal].resize(nodes1D);
+    for (unsigned j = 0; j < nodes1D; ++j) {
+      auto& ord = inverseNodeMapBC[j];
+      sideOrdinalMap[face_ordinal][j] = faceNodeMap[face_ordinal][ord[0]];
+    }
+  }
+}
+//--------------------------------------------------------------------------
+void
+QuadMElementDescription::set_subelement_connectivity()
+{
+  subElementConnectivity.resize((nodes1D-1)*(nodes1D-1));
+  for (unsigned j = 0; j < nodes1D-1; ++j) {
+    for (unsigned i = 0; i < nodes1D-1; ++i) {
+      subElementConnectivity[i+(nodes1D-1)*j] =
+      {
+          static_cast<size_t>(tensor_product_node_map(i,j)),
+          static_cast<size_t>(tensor_product_node_map(i+1,j)),
+          static_cast<size_t>(tensor_product_node_map(i+1,j+1)),
+          static_cast<size_t>(tensor_product_node_map(i,j+1))
+      };
+    }
+  }
+}
+//--------------------------------------------------------------------------
+HexMElementDescription::HexMElementDescription(
+  std::vector<double> in_nodeLocs, std::vector<double> in_scsLoc)
+:  ElementDescription()
+{
+  scsLoc = in_scsLoc;
+  nodeLocs = in_nodeLocs;
+  nodes1D = nodeLocs.size();
+  polyOrder = nodes1D-1;
+  nodesPerElement = nodes1D*nodes1D*nodes1D;
+  dimension = 3;
+  numQuad = (polyOrder % 2 == 0) ? polyOrder/2 + 1 : (polyOrder+1)/2;
+  useGLLGLL = false;
+
+  set_node_connectivity();
+  set_subelement_connectivity();
+
+  quadrature = make_unique<TensorProductQuadratureRule>("GaussLegendre", numQuad, scsLoc);
+  basis = make_unique<LagrangeBasis>(inverseNodeMap, nodeLocs);
+  basisBoundary = make_unique<LagrangeBasis>(inverseNodeMapBC, nodeLocs);
+}
+//--------------------------------------------------------------------------
+void
+HexMElementDescription::set_subelement_connectivity()
+{
+  subElementConnectivity.resize((nodes1D-1)*(nodes1D-1)*(nodes1D-1));
+  for (unsigned k = 0; k < nodes1D-1; ++k) {
+    for (unsigned j = 0; j < nodes1D-1; ++j) {
+      for (unsigned i = 0; i < nodes1D-1; ++i) {
+        subElementConnectivity[i+(nodes1D-1)*(j+(nodes1D-1)*k)] =
+        {
+            static_cast<size_t>(tensor_product_node_map(i+0,j+0,k+0)),
+            static_cast<size_t>(tensor_product_node_map(i+1,j+0,k+0)),
+            static_cast<size_t>(tensor_product_node_map(i+1,j+0,k+1)),
+            static_cast<size_t>(tensor_product_node_map(i+0,j+0,k+1)),
+            static_cast<size_t>(tensor_product_node_map(i+0,j+1,k+0)),
+            static_cast<size_t>(tensor_product_node_map(i+1,j+1,k+0)),
+            static_cast<size_t>(tensor_product_node_map(i+1,j+1,k+1)),
+            static_cast<size_t>(tensor_product_node_map(i+0,j+1,k+1))
+        };
+      }
+    }
+  }
+}
+//--------------------------------------------------------------------------
+void
+HexMElementDescription::set_node_connectivity()
+{
+  unsigned baseNodesPerElement = 8;
+  unsigned nodeNumber = baseNodesPerElement;
+
+  nodeMap.assign(nodes1D*nodes1D*nodes1D,0);
+  auto nmap = [&] (unsigned i, unsigned j, unsigned k) -> unsigned&
+  {
+    return (nodeMap[i+nodes1D*(j+nodes1D*k)]);
+  };
+
+  struct EdgeInfo
+  {
+    int direction;
+    std::vector<int> baseLoc;
+  };
+
+  std::vector<std::pair<std::vector<size_t>, EdgeInfo>>
+  baseEdgeInfo = {
+      {{0,1}, {+1, {0,0,0} }},
+      {{1,2}, {+2, {1,0,0} }},
+      {{2,3}, {-1, {1,1,0} }},
+      {{3,0}, {-2, {0,1,0} }},
+      {{0,4}, {+3, {0,0,0} }},
+      {{1,5}, {+3, {1,0,0} }},
+      {{2,6}, {+3, {1,1,0} }},
+      {{3,7}, {+3, {0,1,0} }},
+      {{4,5}, {+1, {0,0,1} }},
+      {{5,6}, {+2, {1,0,1} }},
+      {{6,7}, {-1, {1,1,1} }},
+      {{7,4}, {-2, {0,1,1} }},
+  };
+
+  //add the base nodes to the map
+  unsigned jmax = nodes1D-1;
+  nmap(0,0,0)          = 0;
+  nmap(jmax,0,0)       = 1;
+  nmap(jmax,jmax,0)    = 2;
+  nmap(0,jmax,0)       = 3;
+  nmap(0,0,jmax)       = 4;
+  nmap(jmax,0,jmax)    = 5;
+  nmap(jmax,jmax,jmax) = 6;
+  nmap(0,jmax,jmax)    = 7;
+
+  std::vector<std::vector<size_t>> baseVolumeNodes = {
+      {0,1,2,3,4,5,6,7}
+  };
+
+  unsigned nodes1DAdded = nodes1D-2;
+  for (auto& baseEdge : baseEdgeInfo) {
+    std::vector<size_t> nodesToAdd(nodes1DAdded);
+    for (unsigned j =0; j < nodes1DAdded; ++j) {
+      nodesToAdd[j] = nodeNumber;
+      ++nodeNumber;
+    }
+    edgeNodeConnectivities.insert({nodesToAdd,baseEdge.first});
+
+    const auto& edgeInfo = baseEdge.second;
+    const auto direction = edgeInfo.direction;
+    const auto& baseLoc = edgeInfo.baseLoc;
+
+    auto reorderedNodes = nodesToAdd;
+    if (direction < 0) {
+      std::reverse(reorderedNodes.begin(), reorderedNodes.end());
+    }
+
+    unsigned il = (baseLoc[0] == 1) ? jmax : 0;
+    unsigned jl = (baseLoc[1] == 1) ? jmax : 0;
+    unsigned kl = (baseLoc[2] == 1) ? jmax : 0;
+
+    switch(std::abs(direction))
+    {
+      case 1:
+      {
+        for (unsigned j = 1; j < polyOrder; ++j) {
+          nmap(j,jl,kl) = reorderedNodes.at(j-1);
+        }
+        break;
+      }
+      case 2:
+      {
+        for (unsigned j = 1; j < polyOrder; ++j) {
+          nmap(il,j,kl) = reorderedNodes.at(j-1);
+        }
+        break;
+      }
+      case 3:
+      {
+        for (unsigned j = 1; j < polyOrder; ++j) {
+          nmap(il,jl,j) = reorderedNodes.at(j-1);
+        }
+        break;
+      }
+      default:
+      {
+        throw std::runtime_error("Invalid direction");
+        break;
+      }
+    }
+    std::vector<std::vector<double>> locs(polyOrder-1);
+    for (unsigned i = 0; i < polyOrder-1; ++i) {
+      locs[i].push_back(nodeLocs[1+i]);
+    }
+    locationsForNewNodes.insert({nodesToAdd,locs});
+  }
+
+  // volume nodes are inserted second to be consistent with exodus format for P=2
+  // (likely for consistency with Hex20 elements), but awkward here
+  unsigned volumeNodeNumber = nodeNumber;
+  for (auto& baseVolume : baseVolumeNodes) {
+    std::vector<size_t> volumeNodesToAdd(nodes1DAdded*nodes1DAdded*nodes1DAdded);
+    for (auto& volumeNodeOrdinal : volumeNodesToAdd) {
+       volumeNodeOrdinal = volumeNodeNumber;
+      ++volumeNodeNumber;
+    }
+    volumeNodeConnectivities.insert({volumeNodesToAdd,baseVolume});
+
+    for (unsigned k = 1; k < polyOrder; ++k) {
+      for (unsigned j = 1; j < polyOrder; ++j) {
+        for (unsigned i = 1; i < polyOrder; ++i) {
+          nmap(i,j,k) =
+            volumeNodesToAdd.at((i-1)+(polyOrder-1)*((j-1)+(polyOrder-1)*(k-1)));
+        }
+      }
+    }
+
+    std::vector<std::vector<double>> locs((polyOrder-1)*(polyOrder-1)*(polyOrder-1));
+    for (unsigned k = 0; k < polyOrder-1; ++k) {
+      for (unsigned j = 0; j < polyOrder-1; ++j) {
+        for (unsigned i = 0; i < polyOrder-1; ++i) {
+          locs[i+(polyOrder-1)*(j+(polyOrder-1)*k)] =
+            {nodeLocs[i+1],nodeLocs[k+1], nodeLocs[j+1]};
+        }
+      }
+    }
+    locationsForNewNodes.insert({volumeNodesToAdd, locs});
+  }
+
+  struct FaceInfo
+  {
+    bool yreflected; // about y
+    bool rotated;
+    int xnormal;
+    int ynormal;
+    int znormal;
+  };
+
+  std::vector<std::pair<std::vector<size_t>, FaceInfo>> baseFaceInfo =
+  {
+      {{0, 3, 2, 1}, {false,true, 0,0,-1}},
+      {{4, 5, 6, 7}, {false,false, 0,0,+1}},
+      {{0, 4, 7, 3}, {false,true, -1,0,0}},
+      {{1, 2, 6, 5}, {false,false, +1,0,0}},
+      {{0, 1, 5, 4}, {false,false,  0,-1,0}},
+      {{2, 3, 7, 6}, {true,false, 0,+1,0}}
+  };
+
+  int faceMap[6] = { 4, 5, 3, 1, 0, 2 };
+
+  unsigned faceNodeNumber = volumeNodeNumber;
+  for (auto& baseFace : baseFaceInfo) {
+    std::vector<size_t> faceNodesToAdd(nodes1DAdded*nodes1DAdded);
+    for (auto& faceNodeOrdinal : faceNodesToAdd) {
+      faceNodeOrdinal = faceNodeNumber;
+      ++faceNodeNumber;
+    }
+    faceNodeConnectivities.insert({faceNodesToAdd,baseFace.first});
+
+    const auto& faceInfo = baseFace.second;
+    const auto xnormal = faceInfo.xnormal;
+    const auto ynormal = faceInfo.ynormal;
+    const auto znormal = faceInfo.znormal;
+    ThrowAssert(std::abs(xnormal)+std::abs(ynormal) + std::abs(znormal) == 1);
+
+    std::vector<size_t> reorderedFaceNodes = faceNodesToAdd;
+    bool isReflected = faceInfo.yreflected;
+    if (isReflected) {
+      reorderedFaceNodes = flip_x<size_t>(faceNodesToAdd, polyOrder-1);
+    }
+
+    bool isRotated = faceInfo.rotated;
+    if (isRotated) {
+      reorderedFaceNodes = transpose_ordinals<size_t>(faceNodesToAdd, polyOrder-1);
+    }
+
+    if (xnormal != 0) {
+      const int il = (xnormal > 0) ? jmax : 0;
+      for (unsigned j = 1; j < polyOrder; ++j) {
+        for (unsigned i = 1; i < polyOrder; ++i) {
+          nmap(il,i,j) = reorderedFaceNodes.at((i-1)+(polyOrder-1)*(j-1));
+        }
+      }
+    }
+
+    if (ynormal != 0) {
+      const int jl = (ynormal > 0) ? jmax : 0;
+      for (unsigned j = 1; j < polyOrder; ++j) {
+        for (unsigned i = 1; i < polyOrder; ++i) {
+          nmap(i,jl,j) = reorderedFaceNodes.at((i-1)+(polyOrder-1)*(j-1));
+        }
+      }
+    }
+
+    if (znormal != 0) {
+      const int kl = (znormal > 0) ? jmax : 0;
+      for (unsigned j = 1; j < polyOrder; ++j) {
+        for (unsigned i = 1; i < polyOrder; ++i) {
+          nmap(i,j,kl) = reorderedFaceNodes.at((i-1)+(polyOrder-1)*(j-1));
+        }
+      }
+    }
+
+    std::vector<std::vector<double>> locs((polyOrder-1)*(polyOrder-1));
+    for (unsigned j = 0; j < polyOrder-1; ++j) {
+      for (unsigned i = 0; i < polyOrder-1; ++i) {
+        locs[i+(polyOrder-1)*j] = {nodeLocs[i+1],nodeLocs[j+1]};
+      }
+    }
+    locationsForNewNodes.insert({faceNodesToAdd, locs});
+  }
+
+  faceNodeMap.resize(6);
+  unsigned faceOrdinal = 0;
+  for (auto& baseFace : baseFaceInfo) {
+    const auto& faceInfo = baseFace.second;
+    const auto xnormal = faceInfo.xnormal;
+    const auto ynormal = faceInfo.ynormal;
+    const auto znormal = faceInfo.znormal;
+    ThrowAssert(std::abs(xnormal)+std::abs(ynormal) + std::abs(znormal) == 1);
+
+    std::vector<size_t> faceNodes(nodes1D*nodes1D);
+    if (xnormal != 0) {
+      const int il = (xnormal > 0) ? jmax : 0;
+      for (unsigned j = 0; j < nodes1D; ++j) {
+        for (unsigned i = 0; i < nodes1D; ++i) {
+          faceNodes[i+nodes1D*j] = nmap(il,i,j);
+        }
+      }
+    }
+
+    if (ynormal != 0) {
+      const int jl = (ynormal > 0) ? jmax : 0;
+      for (unsigned j = 0; j < nodes1D; ++j) {
+        for (unsigned i = 0; i < nodes1D; ++i) {
+          faceNodes[i+nodes1D*j] = nmap(i,jl,j);
+        }
+      }
+    }
+
+    if (znormal != 0) {
+      const int kl = (znormal > 0) ? jmax : 0;
+      for (unsigned j = 0; j < nodes1D; ++j) {
+        for (unsigned i = 0; i < nodes1D; ++i) {
+          faceNodes[i+nodes1D*j] = nmap(i,j,kl);
+        }
+      }
+    }
+
+    faceNodeMap[faceMap[faceOrdinal]] = faceNodes;
+    ++faceOrdinal;
+  }
+
+  // transform face ordinals depending on how they're arranged
+  // in isoparametric coordinates
+  faceNodeMap[2] = flip_x<size_t>(faceNodeMap[2], nodes1D);
+  faceNodeMap[3] = transpose_ordinals<size_t>(faceNodeMap[3], nodes1D);
+  faceNodeMap[4] = transpose_ordinals<size_t>(faceNodeMap[4], nodes1D);
+
+
+  for (const auto& edgeNode : edgeNodeConnectivities) {
+    addedConnectivities.insert(edgeNode);
+  }
+
+  for (const auto& volumeNode : volumeNodeConnectivities) {
+    addedConnectivities.insert(volumeNode);
+  }
+
+  for (const auto& faceNode : faceNodeConnectivities) {
+    addedConnectivities.insert(faceNode);
+  }
+
+  nodeMapBC = QuadMElementDescription(nodeLocs,scsLoc).nodeMap;
+
+  //inverse maps
+  inverseNodeMap.resize(nodes1D*nodes1D*nodes1D);
+  for (unsigned i = 0; i < nodes1D; ++i) {
+    for (unsigned j = 0; j < nodes1D; ++j) {
+      for (unsigned k = 0; k < nodes1D; ++k) {
+        inverseNodeMap[tensor_product_node_map(i,j,k)] = {i, j, k};
+      }
+    }
+  }
+
+  inverseNodeMapBC.resize(nodes1D*nodes1D);
+  for (unsigned i = 0; i < nodes1D; ++i) {
+    for (unsigned j = 0; j < nodes1D; ++j) {
+      inverseNodeMapBC[tensor_product_node_map_bc(i,j)] = { i,j };
+    }
+  }
+
+  sideOrdinalMap.resize(6);
+  for (unsigned face_ordinal = 0; face_ordinal < 6; ++face_ordinal) {
+    sideOrdinalMap[face_ordinal].resize(nodes1D*nodes1D);
+    for (unsigned j = 0; j < nodes1D*nodes1D; ++j) {
+      auto& ords = inverseNodeMapBC[j];
+      sideOrdinalMap[face_ordinal][j] = faceNodeMap[face_ordinal][ords[0]+nodes1D*ords[1]];
+    }
+  }
+}
+
+} // namespace nalu
+}  // namespace sierra

--- a/src/element_promotion/LagrangeBasis.C
+++ b/src/element_promotion/LagrangeBasis.C
@@ -1,0 +1,158 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+#include <element_promotion/LagrangeBasis.h>
+
+#include <stk_util/environment/ReportHandler.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <string>
+
+namespace sierra{
+namespace nalu{
+
+LagrangeBasis::LagrangeBasis(
+  std::vector<std::vector<unsigned>>&  indicesMap,
+  const std::vector<double>& nodeLocs)
+  :  indicesMap_(indicesMap),
+     numNodes1D_(nodeLocs.size()),
+     nodeLocs_(nodeLocs),
+     dimension_(indicesMap[0].size())
+{
+  for (auto& indices : indicesMap) {
+    ThrowRequire(indices.size() == dimension_);
+  }
+  set_lagrange_weights();
+}
+//--------------------------------------------------------------------------
+void
+LagrangeBasis::set_lagrange_weights()
+{
+  lagrangeWeights_.assign(numNodes1D_,1.0);
+  for (unsigned i = 0; i < numNodes1D_; ++i) {
+    for (unsigned j = 0; j < numNodes1D_; ++j) {
+      if ( i != j ) {
+        lagrangeWeights_[i] *= (nodeLocs_[i]-nodeLocs_[j]);
+      }
+    }
+    lagrangeWeights_[i] = 1.0 / lagrangeWeights_[i];
+  }
+}
+//--------------------------------------------------------------------------
+std::vector<double>
+LagrangeBasis::eval_basis_weights(
+  const std::vector<double>& intgLoc) const
+{
+  auto numIps = intgLoc.size() / dimension_;
+  ThrowAssert(numIps * dimension_ == intgLoc.size());
+
+  auto numNodes = std::pow(numNodes1D_, dimension_);
+  std::vector<double> interpolationWeights(numIps*numNodes);
+
+  for (unsigned ip = 0; ip < numIps; ++ip) {
+    unsigned scalar_ip_offset = ip*numNodes;
+    for (unsigned nodeNumber = 0; nodeNumber < numNodes; ++nodeNumber) {
+      unsigned scalar_offset = scalar_ip_offset+nodeNumber;
+      unsigned vector_offset = ip * dimension_;
+      interpolationWeights[scalar_offset]
+          = tensor_lagrange_interpolant( dimension_,
+                                        &intgLoc[vector_offset],
+                                         indicesMap_[nodeNumber].data() );
+    }
+  }
+  return interpolationWeights;
+}
+//--------------------------------------------------------------------------
+std::vector<double>
+LagrangeBasis::eval_deriv_weights(const std::vector<double>& intgLoc) const
+{
+  auto numIps = intgLoc.size()/dimension_;
+  auto numNodes = std::pow(numNodes1D_,dimension_);
+  std::vector<double> derivWeights(numIps * numNodes * dimension_);
+
+  unsigned derivIndex = 0;
+  for (unsigned ip = 0; ip < numIps; ++ip) {
+    for (unsigned nodeNumber = 0; nodeNumber < numNodes; ++nodeNumber) {
+      unsigned vector_offset = ip*dimension_;
+      for (unsigned derivDirection = 0; derivDirection < dimension_; ++derivDirection) {
+        derivWeights[derivIndex]
+            = tensor_lagrange_derivative( dimension_,
+                                         &intgLoc[vector_offset],
+                                          indicesMap_[nodeNumber].data(),
+                                          derivDirection );
+        ++derivIndex;
+      }
+    }
+  }
+  return derivWeights;
+}
+//--------------------------------------------------------------------------
+double
+LagrangeBasis::tensor_lagrange_interpolant(
+  unsigned dimension,
+  const double* x,
+  const unsigned* nodes) const
+{
+  double interpolant_weight = 1.0;
+  for (unsigned j = 0; j < dimension; ++j) {
+    interpolant_weight *= lagrange_1D(x[j], nodes[j]);
+  }
+  return interpolant_weight;
+}
+//--------------------------------------------------------------------------
+double
+LagrangeBasis::tensor_lagrange_derivative(
+  unsigned dimension,
+  const double* x,
+  const unsigned* nodes,
+  unsigned derivativeDirection) const
+{
+  double derivativeWeight = 1.0;
+  for (unsigned j = 0; j < dimension; ++j) {
+    if (j == derivativeDirection) {
+      derivativeWeight *= lagrange_deriv_1D(x[j], nodes[j]);
+    }
+    else {
+      derivativeWeight *= lagrange_1D(x[j], nodes[j]);
+    }
+  }
+  return derivativeWeight;
+}
+//--------------------------------------------------------------------------
+double
+LagrangeBasis::lagrange_1D(double x, unsigned nodeNumber) const
+{
+  double numerator = 1.0;
+  for (unsigned j = 0; j < numNodes1D_; ++j) {
+    if (j != nodeNumber) {
+      numerator *= (x - nodeLocs_[j]);
+    }
+  }
+  return (numerator * lagrangeWeights_[nodeNumber]);
+}
+//--------------------------------------------------------------------------
+double
+LagrangeBasis::lagrange_deriv_1D(double x, unsigned nodeNumber) const
+{
+  double outer = 0.0;
+  for (unsigned j = 0; j < numNodes1D_; ++j) {
+    if (j != nodeNumber) {
+      double inner = 1.0;
+      for (unsigned i = 0; i < numNodes1D_; ++i) {
+        if (i != j && i != nodeNumber) {
+          inner *= (x - nodeLocs_[i]);
+        }
+      }
+      outer += inner;
+    }
+  }
+  return (outer * lagrangeWeights_[nodeNumber]);
+}
+
+}  // namespace nalu
+} // namespace sierra

--- a/src/element_promotion/MasterElementHO.C
+++ b/src/element_promotion/MasterElementHO.C
@@ -1,0 +1,1670 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporatlion.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+#include <element_promotion/MasterElementHO.h>
+#include <element_promotion/ElementDescription.h>
+#include <element_promotion/LagrangeBasis.h>
+
+#include <master_element/MasterElement.h>
+#include <FORTRAN_Proto.h>
+
+#include <array>
+#include <cmath>
+#include <memory>
+#include <stdexcept>
+
+namespace sierra{
+namespace nalu{
+
+HigherOrderHexSCV::HigherOrderHexSCV(const ElementDescription& elem)
+  : MasterElement(),
+    elem_(elem)
+{
+  // TODO(rcknaus): need to pick a modal basis (Hex8 or Hex27, really)
+  // and use it only for geometric calculations (i.e. volume & area)
+  // otherwise, computing the mass matrix scales far too viciously with p, O(p^9)
+  nDim_ = elem_.dimension;
+  nodesPerElement_ = elem_.nodesPerElement;
+
+  // set up integration rule and relevant maps for scvs
+  set_interior_info();
+
+  // compute and save shape functions and derivatives at ips
+  shapeFunctions_ = elem_.eval_basis_weights(intgLoc_);
+  shapeDerivs_ = elem_.eval_deriv_weights(intgLoc_);
+}
+
+//--------------------------------------------------------------------------
+//-------- set_interior_info -----------------------------------------------
+//--------------------------------------------------------------------------
+void
+HigherOrderHexSCV::set_interior_info()
+{
+  //1D integration rule per sub-control volume
+  numIntPoints_ = (elem_.nodes1D * elem_.nodes1D  * elem_.nodes1D)
+                * ( elem_.numQuad * elem_.numQuad * elem_.numQuad);
+
+  // define ip node mappings
+  ipNodeMap_.resize(numIntPoints_);
+  intgLoc_.resize(numIntPoints_*nDim_);
+  intgLocShift_.resize(numIntPoints_*nDim_);
+  ipWeight_.resize(numIntPoints_);
+
+  // tensor product nodes x tensor product quadrature
+  int vector_index = 0; int scalar_index = 0;
+  for (unsigned n = 0; n < elem_.nodes1D; ++n) {
+    for (unsigned m = 0; m < elem_.nodes1D; ++m) {
+      for (unsigned l = 0; l < elem_.nodes1D; ++l) {
+
+        // current node number
+        const int nodeNumber = elem_.tensor_product_node_map(l,m,n);
+
+        //tensor-product quadrature for a particular sub-cv
+        for (unsigned k = 0; k < elem_.numQuad; ++k) {
+          for (unsigned j = 0; j < elem_.numQuad; ++j) {
+            for (unsigned i = 0; i < elem_.numQuad; ++i) {
+              //integration point location
+              intgLoc_[vector_index]     = elem_.gauss_point_location(l,i);
+              intgLoc_[vector_index + 1] = elem_.gauss_point_location(m,j);
+              intgLoc_[vector_index + 2] = elem_.gauss_point_location(n,k);
+
+              //weight
+              ipWeight_[scalar_index] = elem_.tensor_product_weight(l,m,n,i,j,k);
+
+              //sub-control volume association
+              ipNodeMap_[scalar_index] = nodeNumber;
+
+              // increment indices
+              ++scalar_index;
+              vector_index += nDim_;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderHexSCV::shape_fcn(double *shpfc)
+{
+  int numShape = shapeFunctions_.size();
+  for (int j = 0; j < numShape; ++j) {
+    shpfc[j] = shapeFunctions_[j];
+  }
+}
+//--------------------------------------------------------------------------
+const int *
+HigherOrderHexSCV::ipNodeMap(
+  int /*ordinal*/)
+{
+  // define scv->node mappings
+  return &ipNodeMap_[0];
+}
+//--------------------------------------------------------------------------
+void HigherOrderHexSCV::determinant(
+  const int nelem,
+  const double *coords,
+  double *volume,
+  double *error)
+{
+  *error = 0.0;
+  for (int k = 0; k < nelem; ++k) {
+    const int scalar_elem_offset = numIntPoints_ * k;
+    const int coord_elem_offset = nDim_ * nodesPerElement_ * k;
+    for (int ip = 0; ip < numIntPoints_; ++ip) {
+      const int grad_offset = nDim_ * nodesPerElement_ * ip;
+
+      //weighted jacobian determinant
+      const double det_j = jacobian_determinant(
+        &coords[coord_elem_offset],
+        &shapeDerivs_[grad_offset]
+      );
+
+      //apply weight and store to volume
+      volume[scalar_elem_offset + ip] = ipWeight_[ip] * det_j;
+
+      //flag error
+      if (det_j < 0.0) {
+        *error = 1.0;
+      }
+    }
+  }
+}
+//--------------------------------------------------------------------------
+double
+HigherOrderHexSCV::jacobian_determinant(
+  const double *elemNodalCoords,
+  const double *shapeDerivs) const
+{
+  double dx_ds1 = 0.0;  double dx_ds2 = 0.0; double dx_ds3 = 0.0;
+  double dy_ds1 = 0.0;  double dy_ds2 = 0.0; double dy_ds3 = 0.0;
+  double dz_ds1 = 0.0;  double dz_ds2 = 0.0; double dz_ds3 = 0.0;
+  for (int node = 0; node < nodesPerElement_; ++node) {
+    const int vector_offset = nDim_ * node;
+
+    const double xCoord = elemNodalCoords[vector_offset+0];
+    const double yCoord = elemNodalCoords[vector_offset+1];
+    const double zCoord = elemNodalCoords[vector_offset+2];
+
+    const double dn_ds1 = shapeDerivs[vector_offset+0];
+    const double dn_ds2 = shapeDerivs[vector_offset+1];
+    const double dn_ds3 = shapeDerivs[vector_offset+2];
+
+    dx_ds1 += dn_ds1 * xCoord;
+    dx_ds2 += dn_ds2 * xCoord;
+    dx_ds3 += dn_ds3 * xCoord;
+
+    dy_ds1 += dn_ds1 * yCoord;
+    dy_ds2 += dn_ds2 * yCoord;
+    dy_ds3 += dn_ds3 * yCoord;
+
+    dz_ds1 += dn_ds1 * zCoord;
+    dz_ds2 += dn_ds2 * zCoord;
+    dz_ds3 += dn_ds3 * zCoord;
+  }
+
+  const double det_j = dx_ds1 * ( dy_ds2 * dz_ds3 - dz_ds2 * dy_ds3 )
+                     + dy_ds1 * ( dz_ds2 * dx_ds3 - dx_ds2 * dz_ds3 )
+                     + dz_ds1 * ( dx_ds2 * dy_ds3 - dy_ds2 * dx_ds3 );
+
+  return det_j;
+}
+//--------------------------------------------------------------------------
+HigherOrderHexSCS::HigherOrderHexSCS(const ElementDescription& elem)
+: MasterElement(),
+  elem_(elem)
+{
+  nDim_ = elem_.dimension;
+  nodesPerElement_ = elem_.nodesPerElement;
+
+  // set up integration rule and relevant maps on scs
+  set_interior_info();
+
+  // set up integration rule and relevant maps on faces
+  set_boundary_info();
+
+  shapeFunctions_ = elem_.eval_basis_weights(intgLoc_);
+  shapeDerivs_ = elem_.eval_deriv_weights(intgLoc_);
+  expFaceShapeDerivs_ = elem_.eval_deriv_weights(intgExpFace_);
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderHexSCS::set_interior_info()
+{
+  const int surfacesPerDirection = elem_.nodes1D - 1;
+  const int ipsPerSurface = (elem_.numQuad*elem_.numQuad)*(elem_.nodes1D*elem_.nodes1D);
+  const int numSurfaces = surfacesPerDirection * nDim_;
+
+  numIntPoints_ = numSurfaces*ipsPerSurface;
+  const int numVectorPoints = numIntPoints_*nDim_;
+
+  // define L/R mappings
+  lrscv_.resize(2*numIntPoints_);
+
+  // standard integration location
+  intgLoc_.resize(numVectorPoints);
+
+  // shifted
+  intgLocShift_.resize(numVectorPoints);
+
+  // Save quadrature weight and directionality information
+  ipInfo_.resize(numIntPoints_);
+
+  // specify integration point locations in a dimension-by-dimension manner
+  //u direction: bottom-top (0-1)
+  int vector_index = 0; int lrscv_index = 0; int scalar_index = 0;
+  for (int m = 0; m < surfacesPerDirection; ++m) {
+    for (unsigned l = 0; l < elem_.nodes1D; ++l) {
+      for (unsigned k = 0; k < elem_.nodes1D; ++k) {
+
+        int leftNode; int rightNode;
+        if (m % 2 == 0) {
+          leftNode = elem_.tensor_product_node_map(k,l,m);
+          rightNode = elem_.tensor_product_node_map(k,l,m+1);
+        }
+        else {
+          leftNode = elem_.tensor_product_node_map(k,l,m+1);
+          rightNode = elem_.tensor_product_node_map(k,l,m);
+        }
+
+        for (unsigned j = 0; j < elem_.numQuad; ++j) {
+          for (unsigned i = 0; i < elem_.numQuad; ++i) {
+            lrscv_[lrscv_index]     = leftNode;
+            lrscv_[lrscv_index + 1] = rightNode;
+
+            intgLoc_[vector_index]     = elem_.gauss_point_location(k,i);
+            intgLoc_[vector_index + 1] = elem_.gauss_point_location(l,j);
+            intgLoc_[vector_index + 2] = elem_.scsLoc.at(m);
+
+            //compute the quadrature weight
+            ipInfo_[scalar_index].weight = std::pow(-1.0,m+1) * elem_.tensor_product_weight(k,l,i,j);
+
+            //direction
+            ipInfo_[scalar_index].direction = Jacobian::U_DIRECTION;
+
+            ++scalar_index;
+            lrscv_index += 2;
+            vector_index += nDim_;
+          }
+        }
+      }
+    }
+  }
+
+  //t direction: front-back (2-3)
+  for (int m = 0; m < surfacesPerDirection; ++m) {
+    for (unsigned l = 0; l < elem_.nodes1D; ++l) {
+      for (unsigned k = 0; k < elem_.nodes1D; ++k) {
+
+        int leftNode; int rightNode;
+        if (m % 2 == 0) {
+          leftNode = elem_.tensor_product_node_map(k,m,l);
+          rightNode = elem_.tensor_product_node_map(k,m+1,l);
+        }
+        else {
+          leftNode = elem_.tensor_product_node_map(k,m+1,l);
+          rightNode = elem_.tensor_product_node_map(k,m,l);
+        }
+
+        for (unsigned j = 0; j < elem_.numQuad; ++j) {
+          for (unsigned i = 0; i < elem_.numQuad; ++i) {
+            lrscv_[lrscv_index]     = leftNode;
+            lrscv_[lrscv_index + 1] = rightNode;
+
+            intgLoc_[vector_index]     = elem_.gauss_point_location(k,i);
+            intgLoc_[vector_index + 1] = elem_.scsLoc[m];
+            intgLoc_[vector_index + 2] = elem_.gauss_point_location(l,j);
+
+            //compute the quadrature weight
+            ipInfo_[scalar_index].weight = std::pow(-1.0,m+1) * elem_.tensor_product_weight(k,l,i,j);
+
+            //direction
+            ipInfo_[scalar_index].direction = Jacobian::T_DIRECTION;
+
+            ++scalar_index;
+            lrscv_index += 2;
+            vector_index += nDim_;
+          }
+        }
+      }
+    }
+  }
+
+  //s direction: left-right (4-5)
+  for (int m = 0; m < surfacesPerDirection; ++m) {
+    for (unsigned l = 0; l < elem_.nodes1D; ++l) {
+      for (unsigned k = 0; k < elem_.nodes1D; ++k) {
+
+        int leftNode; int rightNode;
+        if (m % 2 == 0) {
+          leftNode = elem_.tensor_product_node_map(m,k,l);
+          rightNode = elem_.tensor_product_node_map(m+1,k,l);
+        }
+        else {
+          leftNode = elem_.tensor_product_node_map(m+1,k,l);
+          rightNode = elem_.tensor_product_node_map(m,k,l);
+        }
+
+        for (unsigned j = 0; j < elem_.numQuad; ++j) {
+          for (unsigned i = 0; i < elem_.numQuad; ++i) {
+            lrscv_[lrscv_index]     = leftNode;
+            lrscv_[lrscv_index + 1] = rightNode;
+
+            intgLoc_[vector_index]     = elem_.scsLoc[m];
+            intgLoc_[vector_index + 1] = elem_.gauss_point_location(k,i);
+            intgLoc_[vector_index + 2] = elem_.gauss_point_location(l,j);
+
+            //compute the quadrature weight
+            ipInfo_[scalar_index].weight = std::pow(-1.0, m) * elem_.tensor_product_weight(k,l,i,j);
+
+            //direction
+            ipInfo_[scalar_index].direction = Jacobian::S_DIRECTION;
+
+            ++scalar_index;
+            lrscv_index += 2;
+            vector_index += nDim_;
+          }
+        }
+      }
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- set_boundary_info -----------------------------------------------
+//--------------------------------------------------------------------------
+void
+HigherOrderHexSCS::set_boundary_info()
+{
+  const int numFaces = 2 * nDim_;
+  int numQuad = static_cast<int>(elem_.numQuad);
+  int nodes1D = static_cast<int>(elem_.nodes1D);
+  const int nodesPerFace = nodes1D * nodes1D;
+  ipsPerFace_ = nodesPerFace * (numQuad * numQuad);
+  int surfacesPerDirection = nodes1D - 1;
+  const int numFaceIps = numFaces * ipsPerFace_;
+
+  oppFace_.resize(numFaceIps);
+  ipNodeMap_.resize(numFaceIps);
+  oppNode_.resize(numFaceIps);
+  intgExpFace_.resize(numFaceIps*nDim_);
+
+  // tensor-product style access to the map
+  auto face_node_number = [&] (int i, int j, int faceOrdinal)
+  {
+    return elem_.faceNodeMap[faceOrdinal][i + nodes1D * j];
+  };
+
+  // map face ip ordinal to nearest sub-control surface ip ordinal
+  // sub-control surface renumbering
+  const std::vector<int> faceToSurface = {
+      surfacesPerDirection,     // nearest scs face to t=-1.0
+      3*surfacesPerDirection-1, // nearest scs face to s=+1.0, the last face
+      2*surfacesPerDirection-1, // nearest scs face to t=+1.0
+      2*surfacesPerDirection,   // nearest scs face to s=-1.0
+      0,                        // nearest scs face to u=-1.0, the first face
+      surfacesPerDirection-1    // nearest scs face to u=+1.0, the first face
+  };
+  auto opp_face_map = [&] ( int k, int l, int i, int j, int face_index)
+  {
+    int face_offset = faceToSurface[face_index] * ipsPerFace_;
+
+    int node_index = k + nodes1D * l;
+    int node_offset = node_index * (numQuad * numQuad);
+
+    int ip_index = face_offset+node_offset+i+numQuad*j;
+
+    return ip_index;
+   };
+
+  // location of the faces in the correct order
+  const std::vector<double> faceLoc = {-1.0, +1.0, +1.0, -1.0, -1.0, +1.0};
+
+  // Set points face-by-face
+  int vector_index = 0; int scalar_index = 0; int faceOrdinal = 0;
+
+  // front face: t = -1.0: counter-clockwise
+  faceOrdinal = 0;
+  for (int l = 0; l < nodes1D; ++l) {
+    for (int k = 0; k < nodes1D; ++k) {
+      const int nearNode = face_node_number(k,l,faceOrdinal);
+      int oppNode = elem_.tensor_product_node_map(k,1,l);
+
+      //tensor-product quadrature for a particular sub-cv
+      for (int j = 0; j < numQuad; ++j) {
+        for (int i = 0; i < numQuad; ++i) {
+          // set maps
+          ipNodeMap_[scalar_index] = nearNode;
+          oppNode_[scalar_index] = oppNode;
+          oppFace_[scalar_index] = opp_face_map(k,l,i,j,faceOrdinal);
+
+          //integration point location
+          intgExpFace_[vector_index]     = intgLoc_[oppFace_[scalar_index]*nDim_+0];
+          intgExpFace_[vector_index + 1] = faceLoc[faceOrdinal];
+          intgExpFace_[vector_index + 2] = intgLoc_[oppFace_[scalar_index]*nDim_+2];
+
+          // increment indices
+          ++scalar_index;
+          vector_index += nDim_;
+        }
+      }
+    }
+  }
+
+  // right face: s = +1.0: counter-clockwise
+  faceOrdinal = 1;
+  for (int l = 0; l < nodes1D; ++l) {
+    for (int k = 0; k < nodes1D; ++k) {
+      const int nearNode = face_node_number(k,l,faceOrdinal);
+      int oppNode = elem_.tensor_product_node_map(nodes1D-2,k,l);
+
+      //tensor-product quadrature for a particular sub-cv
+      for (int j = 0; j < numQuad; ++j) {
+        for (int i = 0; i < numQuad; ++i) {
+          // set maps
+          ipNodeMap_[scalar_index] = nearNode;
+          oppNode_[scalar_index] = oppNode;
+          oppFace_[scalar_index] = opp_face_map(k,l,i,j,faceOrdinal);
+
+          //integration point location
+          intgExpFace_[vector_index]     = faceLoc[faceOrdinal];
+          intgExpFace_[vector_index + 1] = intgLoc_[oppFace_[scalar_index]*nDim_+1];
+          intgExpFace_[vector_index + 2] = intgLoc_[oppFace_[scalar_index]*nDim_+2];
+
+          // increment indices
+          ++scalar_index;
+          vector_index += nDim_;
+        }
+      }
+    }
+  }
+
+  // back face: t = +1.0: s-direction reversed
+  faceOrdinal = 2;
+  for (int l = 0; l < nodes1D; ++l) {
+    for (int k = nodes1D-1; k >= 0; --k) {
+      const int nearNode = face_node_number(k,l,faceOrdinal);
+      int oppNode = elem_.tensor_product_node_map(k,nodes1D-2,l);
+
+      //tensor-product quadrature for a particular sub-cv
+      for (int j = 0; j < numQuad; ++j) {
+        for (int i = numQuad-1; i >= 0; --i) {
+          // set maps
+          ipNodeMap_[scalar_index] = nearNode;
+          oppNode_[scalar_index] = oppNode;
+          oppFace_[scalar_index] = opp_face_map(k,l,i,j,faceOrdinal);
+
+          //integration point location
+          intgExpFace_[vector_index]     = intgLoc_[oppFace_[scalar_index]*nDim_+0];
+          intgExpFace_[vector_index + 1] = faceLoc[faceOrdinal];
+          intgExpFace_[vector_index + 2] = intgLoc_[oppFace_[scalar_index]*nDim_+2];
+
+          // increment indices
+          ++scalar_index;
+          vector_index += nDim_;
+        }
+      }
+    }
+  }
+
+  //left face: x = -1.0 swapped t and u
+  faceOrdinal = 3;
+  for (int l = 0; l < nodes1D; ++l) {
+    for (int k = 0; k < nodes1D; ++k) {
+      const int nearNode = face_node_number(l,k,faceOrdinal);
+      int oppNode = elem_.tensor_product_node_map(1,l,k);
+
+      //tensor-product quadrature for a particular sub-cv
+      for (int j = 0; j < numQuad; ++j) {
+        for (int i = 0; i < numQuad; ++i) {
+          // set maps
+          ipNodeMap_[scalar_index] = nearNode;
+          oppNode_[scalar_index]   = oppNode;
+          oppFace_[scalar_index]   = opp_face_map(l,k,j,i,faceOrdinal);
+
+          //integration point location
+          intgExpFace_[vector_index]     = faceLoc[faceOrdinal];
+          intgExpFace_[vector_index + 1] = intgLoc_[oppFace_[scalar_index]*nDim_+1];
+          intgExpFace_[vector_index + 2] = intgLoc_[oppFace_[scalar_index]*nDim_+2];
+
+          // increment indices
+          ++scalar_index;
+          vector_index += nDim_;
+        }
+      }
+    }
+  }
+
+  //bottom face: u = -1.0: swapped s and t
+  faceOrdinal = 4;
+  for (int l = 0; l < nodes1D; ++l) {
+    for (int k = 0; k < nodes1D; ++k) {
+      const int nearNode = face_node_number(l,k,faceOrdinal);
+      int oppNode = elem_.tensor_product_node_map(l,k,1);
+
+      //tensor-product quadrature for a particular sub-cv
+      for (int j = 0; j < numQuad; ++j) {
+        for (int i = 0; i < numQuad; ++i) {
+          // set maps
+          ipNodeMap_[scalar_index] = nearNode;
+          oppNode_[scalar_index] = oppNode;
+          oppFace_[scalar_index] = opp_face_map(l,k,j,i,faceOrdinal);
+
+          //integration point location
+          intgExpFace_[vector_index]     = intgLoc_[oppFace_[scalar_index]*nDim_+0];
+          intgExpFace_[vector_index + 1] = intgLoc_[oppFace_[scalar_index]*nDim_+1];
+          intgExpFace_[vector_index + 2] = faceLoc[faceOrdinal];
+
+          // increment indices
+          ++scalar_index;
+          vector_index += nDim_;
+        }
+      }
+    }
+  }
+
+  //top face: u = +1.0: counter-clockwise
+  faceOrdinal = 5;
+  for (int l = 0; l < nodes1D; ++l) {
+    for (int k = 0; k < nodes1D; ++k) {
+      const int nearNode = face_node_number(k,l,faceOrdinal);
+      int oppNode = elem_.tensor_product_node_map(k,l,nodes1D-2);
+
+      //tensor-product quadrature for a particular sub-cv
+      for (int j = 0; j < numQuad; ++j) {
+        for (int i = 0; i < numQuad; ++i) {
+          // set maps
+          ipNodeMap_[scalar_index] = nearNode;
+          oppNode_[scalar_index] = oppNode;
+          oppFace_[scalar_index] = opp_face_map(k,l,i,j,faceOrdinal);
+
+          //integration point location
+          intgExpFace_[vector_index]     = intgLoc_[oppFace_[scalar_index]*nDim_+0];
+          intgExpFace_[vector_index + 1] = intgLoc_[oppFace_[scalar_index]*nDim_+1];
+          intgExpFace_[vector_index + 2] = faceLoc[faceOrdinal];
+
+          // increment indices
+          ++scalar_index;
+          vector_index += nDim_;
+        }
+      }
+    }
+  }
+  //throw std::runtime_error("check");
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderHexSCS::shape_fcn(double* shpfc)
+{
+  int numShape = shapeFunctions_.size();
+  for (int j = 0; j < numShape; ++j) {
+    shpfc[j] = shapeFunctions_[j];
+  }
+}
+//--------------------------------------------------------------------------
+const int *
+HigherOrderHexSCS::adjacentNodes()
+{
+  // define L/R mappings
+  return &lrscv_[0];
+}
+//--------------------------------------------------------------------------
+const int *
+HigherOrderHexSCS::ipNodeMap(
+  int ordinal)
+{
+  // define ip->node mappings for each face (ordinal);
+  return &ipNodeMap_[ordinal*ipsPerFace_];
+}
+//--------------------------------------------------------------------------
+int
+HigherOrderHexSCS::opposingNodes(
+  const int ordinal,
+  const int node)
+{
+  return oppNode_[ordinal*ipsPerFace_+node];
+}
+//--------------------------------------------------------------------------
+int
+HigherOrderHexSCS::opposingFace(
+  const int ordinal,
+  const int node)
+{
+  return oppFace_[ordinal*ipsPerFace_+node];
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderHexSCS::determinant(
+  const int nelem,
+  const double *coords,
+  double *areav,
+  double *error)
+{
+  //returns the normal vector x_t x x_u for constant s curves
+  //returns the normal vector x_u x x_s for constant t curves
+  //returns the normal vector x_s x x_t for constant u curves
+  std::array<double,3> areaVector;
+
+  for (int k = 0; k < nelem; ++k) {
+    const int coord_elem_offset = nDim_ * nodesPerElement_ * k;
+    const int vector_elem_offset = nDim_ * numIntPoints_ * k;
+
+    for (int ip = 0; ip < numIntPoints_; ++ip) {
+      const int grad_offset = nDim_ * nodesPerElement_ * ip;
+      const int offset = nDim_ * ip + vector_elem_offset;
+
+      //compute area vector for this ip
+      area_vector( ipInfo_[ip].direction,
+        &coords[coord_elem_offset],
+        &shapeDerivs_[grad_offset],
+        areaVector );
+
+      // apply quadrature weight and orientation (combined as weight)
+      for (int j = 0; j < nDim_; ++j) {
+        areav[offset+j]  = ipInfo_[ip].weight * areaVector[j];
+      }
+    }
+  }
+
+  *error = 0;
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderHexSCS::area_vector(
+  const Jacobian::Direction direction,
+  const double *elemNodalCoords,
+  double *shapeDeriv,
+  std::array<double,3>& areaVector) const
+{
+
+  int s1Component; int s2Component;
+  switch (direction) {
+    case Jacobian::S_DIRECTION:
+      s1Component = static_cast<int>(Jacobian::T_DIRECTION);
+      s2Component = static_cast<int>(Jacobian::U_DIRECTION);
+      break;
+    case Jacobian::T_DIRECTION:
+      s1Component = static_cast<int>(Jacobian::S_DIRECTION);
+      s2Component = static_cast<int>(Jacobian::U_DIRECTION);
+      break;
+    case Jacobian::U_DIRECTION:
+      s1Component = static_cast<int>(Jacobian::T_DIRECTION);
+      s2Component = static_cast<int>(Jacobian::S_DIRECTION);
+      break;
+    default:
+      throw std::runtime_error("Not a valid direction for this element!");
+  }
+
+  // return the normal area vector given shape derivatives dnds OR dndt
+  double dx_ds1 = 0.0; double dy_ds1 = 0.0; double dz_ds1 = 0.0;
+  double dx_ds2 = 0.0; double dy_ds2 = 0.0; double dz_ds2 = 0.0;
+
+  for (int node = 0; node < nodesPerElement_; ++node) {
+    const int vector_offset = nDim_ * node;
+    const double xCoord = elemNodalCoords[vector_offset+0];
+    const double yCoord = elemNodalCoords[vector_offset+1];
+    const double zCoord = elemNodalCoords[vector_offset+2];
+
+    const double dn_ds1 = shapeDeriv[vector_offset+s1Component];
+    const double dn_ds2 = shapeDeriv[vector_offset+s2Component];
+
+    dx_ds1 += dn_ds1 * xCoord;
+    dx_ds2 += dn_ds2 * xCoord;
+
+    dy_ds1 += dn_ds1 * yCoord;
+    dy_ds2 += dn_ds2 * yCoord;
+
+    dz_ds1 += dn_ds1 * zCoord;
+    dz_ds2 += dn_ds2 * zCoord;
+  }
+
+  //cross product
+  areaVector[0] = dy_ds1*dz_ds2 - dz_ds1*dy_ds2;
+  areaVector[1] = dz_ds1*dx_ds2 - dx_ds1*dz_ds2;
+  areaVector[2] = dx_ds1*dy_ds2 - dy_ds1*dx_ds2;
+}
+//--------------------------------------------------------------------------
+void HigherOrderHexSCS::grad_op(
+  const int nelem,
+  const double *coords,
+  double *gradop,
+  double *deriv,
+  double *det_j,
+  double *error)
+{
+  for (int k = 0; k < nelem; ++k) {
+    const int coord_elem_offset = nDim_ * nodesPerElement_ * k;
+    const int scalar_elem_offset = numIntPoints_ * k;
+    const int grad_elem_offset = numIntPoints_ * nDim_ * nodesPerElement_ * k;
+
+    for (int ip = 0; ip < numIntPoints_; ++ip) {
+      const int grad_offset = nDim_ * nodesPerElement_ * ip;
+      const int offset = grad_offset + grad_elem_offset;
+
+      for (int j = 0; j < nodesPerElement_ * nDim_; ++j) {
+        deriv[offset + j] = shapeDerivs_[grad_offset +j];
+      }
+
+      gradient( &coords[coord_elem_offset],
+        &shapeDerivs_[grad_offset],
+        &gradop[offset],
+        &det_j[scalar_elem_offset+ip] );
+
+      if (det_j[ip] <= 0.0) {
+        *error = 1.0;
+      }
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- face_grad_op ----------------------------------------------------
+//--------------------------------------------------------------------------
+void HigherOrderHexSCS::face_grad_op(
+  const int nelem,
+  const int face_ordinal,
+  const double *coords,
+  double *gradop,
+  double *det_j,
+  double *error)
+{
+  const int face_offset =  nDim_ * ipsPerFace_ * nodesPerElement_ * face_ordinal;
+  for (int k = 0; k < nelem; ++k) {
+    const int coord_elem_offset = nDim_ * nodesPerElement_ * k;
+    const int scalar_elem_offset = ipsPerFace_ * k;
+    const int grad_elem_offset = ipsPerFace_ * nDim_ * nodesPerElement_ * k;
+
+    for (int ip = 0; ip < ipsPerFace_; ++ip) {
+      const int grad_offset = nDim_ * nodesPerElement_ * ip;
+      const int offset = grad_offset + grad_elem_offset;
+
+      gradient( &coords[coord_elem_offset],
+        &expFaceShapeDerivs_[face_offset+grad_offset],
+        &gradop[offset],
+        &det_j[scalar_elem_offset+ip] );
+
+      if (det_j[ip] <= 0.0) {
+        *error = 1.0;
+      }
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- gradient --------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+HigherOrderHexSCS::gradient(
+  const double* elemNodalCoords,
+  const double* shapeDeriv,
+  double* grad,
+  double* det_j) const
+{
+  double dx_ds1 = 0.0;  double dx_ds2 = 0.0; double dx_ds3 = 0.0;
+  double dy_ds1 = 0.0;  double dy_ds2 = 0.0; double dy_ds3 = 0.0;
+  double dz_ds1 = 0.0;  double dz_ds2 = 0.0; double dz_ds3 = 0.0;
+
+  //compute Jacobian
+  for (int node = 0; node < nodesPerElement_; ++node) {
+    const int vector_offset = nDim_ * node;
+
+    const double xCoord = elemNodalCoords[vector_offset + 0];
+    const double yCoord = elemNodalCoords[vector_offset + 1];
+    const double zCoord = elemNodalCoords[vector_offset + 2];
+
+    const double dn_ds1 = shapeDeriv[vector_offset + 0];
+    const double dn_ds2 = shapeDeriv[vector_offset + 1];
+    const double dn_ds3 = shapeDeriv[vector_offset + 2];
+
+    dx_ds1 += dn_ds1 * xCoord;
+    dx_ds2 += dn_ds2 * xCoord;
+    dx_ds3 += dn_ds3 * xCoord;
+
+    dy_ds1 += dn_ds1 * yCoord;
+    dy_ds2 += dn_ds2 * yCoord;
+    dy_ds3 += dn_ds3 * yCoord;
+
+    dz_ds1 += dn_ds1 * zCoord;
+    dz_ds2 += dn_ds2 * zCoord;
+    dz_ds3 += dn_ds3 * zCoord;
+  }
+
+  *det_j = dx_ds1 * ( dy_ds2 * dz_ds3 - dz_ds2 * dy_ds3 )
+               + dy_ds1 * ( dz_ds2 * dx_ds3 - dx_ds2 * dz_ds3 )
+               + dz_ds1 * ( dx_ds2 * dy_ds3 - dy_ds2 * dx_ds3 );
+
+  const double inv_det_j = (*det_j > 0.0) ? 1.0 / (*det_j) : 0.0;
+
+  const double ds1_dx = inv_det_j*(dy_ds2 * dz_ds3 - dz_ds2 * dy_ds3);
+  const double ds2_dx = inv_det_j*(dz_ds1 * dy_ds3 - dy_ds1 * dz_ds3);
+  const double ds3_dx = inv_det_j*(dy_ds1 * dz_ds2 - dz_ds1 * dy_ds2);
+
+  const double ds1_dy = inv_det_j*(dz_ds2 * dx_ds3 - dx_ds2 * dz_ds3);
+  const double ds2_dy = inv_det_j*(dx_ds1 * dz_ds3 - dz_ds1 * dx_ds3);
+  const double ds3_dy = inv_det_j*(dz_ds1 * dx_ds2 - dx_ds1 * dz_ds2);
+
+  const double ds1_dz = inv_det_j*(dx_ds2 * dy_ds3 - dy_ds2 * dx_ds3);
+  const double ds2_dz = inv_det_j*(dy_ds1 * dx_ds3 - dx_ds1 * dy_ds3);
+  const double ds3_dz = inv_det_j*(dx_ds1 * dy_ds2 - dy_ds1 * dx_ds2);
+
+  // metrics
+  for (int node = 0; node < nodesPerElement_; ++node) {
+    const int vector_offset = nDim_ * node;
+
+    const double dn_ds1 = shapeDeriv[vector_offset + 0];
+    const double dn_ds2 = shapeDeriv[vector_offset + 1];
+    const double dn_ds3 = shapeDeriv[vector_offset + 2];
+
+    grad[vector_offset + 0] = dn_ds1 * ds1_dx + dn_ds2 * ds2_dx + dn_ds3 * ds3_dx;
+    grad[vector_offset + 1] = dn_ds1 * ds1_dy + dn_ds2 * ds2_dy + dn_ds3 * ds3_dy;
+    grad[vector_offset + 2] = dn_ds1 * ds1_dz + dn_ds2 * ds2_dz + dn_ds3 * ds3_dz;
+  }
+}
+//--------------------------------------------------------------------------
+//-------- gij -------------------------------------------------------------
+//--------------------------------------------------------------------------
+void HigherOrderHexSCS::gij(
+  const double *coords,
+  double *gupperij,
+  double *glowerij,
+  double *deriv)
+{
+  SIERRA_FORTRAN(threed_gij)
+    ( &nodesPerElement_,
+      &numIntPoints_,
+      deriv,
+      coords, gupperij, glowerij);
+}
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+HigherOrderQuad3DSCS::HigherOrderQuad3DSCS(const ElementDescription& elem)
+: MasterElement(),
+  elem_(elem)
+{
+  surfaceDimension_ = 2;
+  nDim_ = 3;
+  nodesPerElement_ = elem_.nodes1D * elem_.nodes1D;
+
+  // set up integration rule and relevant maps on scs
+  set_interior_info();
+
+  // compute and save shape functions and derivatives at ips
+  shapeFunctions_ = elem_.basisBoundary->eval_basis_weights(intgLoc_);
+  shapeDerivs_ = elem_.basisBoundary->eval_deriv_weights(intgLoc_);
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderQuad3DSCS::set_interior_info()
+{
+  nodesPerElement_ = elem_.nodes1D * elem_.nodes1D;
+
+  //1D integration rule per sub-control volume
+  numIntPoints_ = (elem_.nodes1D * elem_.nodes1D) * ( elem_.numQuad * elem_.numQuad );
+
+  // define ip node mappings
+  ipNodeMap_.resize(numIntPoints_);
+  intgLoc_.resize(numIntPoints_*surfaceDimension_);
+  intgLocShift_.resize(numIntPoints_*surfaceDimension_);
+  ipWeight_.resize(numIntPoints_);
+
+  // tensor product nodes x tensor product quadrature
+  int vector_index_2D = 0; int scalar_index = 0;
+  for (unsigned l = 0; l < elem_.nodes1D; ++l) {
+    for (unsigned k = 0; k < elem_.nodes1D; ++k) {
+      for (unsigned j = 0; j < elem_.numQuad; ++j) {
+        for (unsigned i = 0; i < elem_.numQuad; ++i) {
+          //integration point location
+          intgLoc_[vector_index_2D]     = elem_.gauss_point_location(k,i);
+          intgLoc_[vector_index_2D + 1] = elem_.gauss_point_location(l,j);
+
+          //weight
+          ipWeight_[scalar_index] = elem_.tensor_product_weight(k,l,i,j);
+
+          //sub-control volume association
+          ipNodeMap_[scalar_index] = elem_.tensor_product_node_map_bc(k,l);
+
+          // increment indices
+          ++scalar_index;
+          vector_index_2D += surfaceDimension_;
+        }
+      }
+    }
+  }
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderQuad3DSCS::shape_fcn(double* shpfc)
+{
+  int numShape = shapeFunctions_.size();
+  for (int j = 0; j < numShape; ++j) {
+    shpfc[j] = shapeFunctions_[j];
+  }
+}
+//--------------------------------------------------------------------------
+const int *
+HigherOrderQuad3DSCS::ipNodeMap(
+  int /*ordinal*/)
+{
+  // define ip->node mappings for each face (single ordinal);
+  return &ipNodeMap_[0];
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderQuad3DSCS::determinant(
+  const int nelem,
+  const double *coords,
+  double *areav,
+  double * /*error*/)
+{
+  std::array<double,3> areaVector;
+
+  for (int k = 0; k < nelem; ++k) {
+    const int coord_elem_offset = nDim_ * nodesPerElement_ * k;
+    const int vector_elem_offset = nDim_ * numIntPoints_ * k;
+
+    for (int ip = 0; ip < numIntPoints_; ++ip) {
+      const int grad_offset = surfaceDimension_ * nodesPerElement_ * ip;
+      const int offset = nDim_ * ip + vector_elem_offset;
+
+      //compute area vector for this ip
+      area_vector( &coords[coord_elem_offset],
+        &shapeDerivs_[grad_offset],
+        areaVector );
+
+      // apply quadrature weight and orientation (combined as weight)
+      for (int j = 0; j < nDim_; ++j) {
+        areav[offset+j]  = ipWeight_[ip] * areaVector[j];
+      }
+    }
+  }
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderQuad3DSCS::area_vector(
+  const double *elemNodalCoords,
+  const double *shapeDeriv,
+  std::array<double,3>& areaVector) const
+{
+  // return the normal area vector given shape derivatives dnds OR dndt
+  double dx_ds1 = 0.0; double dy_ds1 = 0.0; double dz_ds1 = 0.0;
+  double dx_ds2 = 0.0; double dy_ds2 = 0.0; double dz_ds2 = 0.0;
+
+  for (int node = 0; node < nodesPerElement_; ++node) {
+    const int vector_offset = nDim_ * node;
+    const int surface_vector_offset = surfaceDimension_ * node;
+
+    const double xCoord = elemNodalCoords[vector_offset+0];
+    const double yCoord = elemNodalCoords[vector_offset+1];
+    const double zCoord = elemNodalCoords[vector_offset+2];
+
+    const double dn_ds1 = shapeDeriv[surface_vector_offset+0];
+    const double dn_ds2 = shapeDeriv[surface_vector_offset+1];
+
+    dx_ds1 += dn_ds1 * xCoord;
+    dx_ds2 += dn_ds2 * xCoord;
+
+    dy_ds1 += dn_ds1 * yCoord;
+    dy_ds2 += dn_ds2 * yCoord;
+
+    dz_ds1 += dn_ds1 * zCoord;
+    dz_ds2 += dn_ds2 * zCoord;
+  }
+
+  //cross product
+  areaVector[0] = dy_ds1 * dz_ds2 - dz_ds1 * dy_ds2;
+  areaVector[1] = dz_ds1 * dx_ds2 - dx_ds1 * dz_ds2;
+  areaVector[2] = dx_ds1 * dy_ds2 - dy_ds1 * dx_ds2;
+}
+//--------------------------------------------------------------------------
+HigherOrderQuad2DSCV::HigherOrderQuad2DSCV(const ElementDescription& elem)
+: MasterElement(),
+  elem_(elem)
+{
+  nDim_ = elem_.dimension;
+  nodesPerElement_ = elem_.nodesPerElement;
+
+  // set up integration rule and relevant maps for scvs
+  set_interior_info();
+
+  // compute and save shape functions and derivatives at ips
+  shapeFunctions_ = elem_.eval_basis_weights(intgLoc_);
+  shapeDerivs_ = elem_.eval_deriv_weights(intgLoc_);
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderQuad2DSCV::set_interior_info()
+{
+  //1D integration rule per sub-control volume
+  numIntPoints_ = (elem_.nodes1D * elem_.nodes1D) * ( elem_.numQuad * elem_.numQuad );
+
+  // define ip node mappings
+  ipNodeMap_.resize(numIntPoints_);
+  intgLoc_.resize(numIntPoints_*nDim_);
+  intgLocShift_.resize(numIntPoints_*nDim_);
+  ipWeight_.resize(numIntPoints_);
+
+  // tensor product nodes x tensor product quadrature
+  int vector_index = 0; int scalar_index = 0;
+  for (unsigned l = 0; l < elem_.nodes1D; ++l) {
+    for (unsigned k = 0; k < elem_.nodes1D; ++k) {
+      for (unsigned j = 0; j < elem_.numQuad; ++j) {
+        for (unsigned i = 0; i < elem_.numQuad; ++i) {
+          intgLoc_[vector_index]     = elem_.gauss_point_location(k,i);
+          intgLoc_[vector_index + 1] = elem_.gauss_point_location(l,j);
+          ipWeight_[scalar_index] = elem_.tensor_product_weight(k,l,i,j);
+          ipNodeMap_[scalar_index] = elem_.tensor_product_node_map(k,l);
+
+          // increment indices
+          ++scalar_index;
+          vector_index += nDim_;
+        }
+      }
+    }
+  }
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderQuad2DSCV::shape_fcn(double *shpfc)
+{
+  int numShape = shapeFunctions_.size();
+  for (int j = 0; j < numShape; ++j) {
+    shpfc[j] = shapeFunctions_[j];
+  }
+}
+//--------------------------------------------------------------------------
+const int *
+HigherOrderQuad2DSCV::ipNodeMap(int /*ordinal*/)
+{
+  return &ipNodeMap_[0];
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderQuad2DSCV::determinant(
+  const int nelem,
+  const double *coords,
+  double *volume,
+  double *error)
+{
+  *error = 0.0;
+  for (int k = 0; k < nelem; ++k) {
+    const int scalar_elem_offset = numIntPoints_ * k;
+    const int coord_elem_offset = nDim_ * nodesPerElement_ * k;
+    for (int ip = 0; ip < numIntPoints_; ++ip) {
+      const int grad_offset = nDim_ * nodesPerElement_ * ip;
+
+      //weighted jacobian determinant
+      const double det_j = jacobian_determinant( &coords[coord_elem_offset],
+        &shapeDerivs_[grad_offset] );
+
+      //apply weight and store to volume
+      volume[scalar_elem_offset + ip] = ipWeight_[ip] * det_j;
+
+      //flag error
+      if (det_j <= 0.0) {
+        *error = 1.0;
+      }
+    }
+  }
+}
+//--------------------------------------------------------------------------
+double
+HigherOrderQuad2DSCV::jacobian_determinant(
+  const double *elemNodalCoords,
+  const double *shapeDerivs) const
+{
+  double dx_ds1 = 0.0;  double dx_ds2 = 0.0;
+  double dy_ds1 = 0.0;  double dy_ds2 = 0.0;
+
+  for (int node = 0; node < nodesPerElement_; ++node) {
+    const int vector_offset = node * nDim_;
+
+    const double xCoord = elemNodalCoords[vector_offset + 0];
+    const double yCoord = elemNodalCoords[vector_offset + 1];
+
+    const double dn_ds1  = shapeDerivs[vector_offset + 0];
+    const double dn_ds2  = shapeDerivs[vector_offset + 1];
+
+    dx_ds1 += dn_ds1 * xCoord;
+    dx_ds2 += dn_ds2 * xCoord;
+
+    dy_ds1 += dn_ds1 * yCoord;
+    dy_ds2 += dn_ds2 * yCoord;
+  }
+
+  const double det_j = dx_ds1 * dy_ds2 - dy_ds1 * dx_ds2;
+  return det_j;
+}
+//--------------------------------------------------------------------------
+HigherOrderQuad2DSCS::HigherOrderQuad2DSCS(const ElementDescription& elem)
+: MasterElement(),
+  elem_(elem)
+{
+  nDim_ = 2;
+  nodesPerElement_ = elem_.nodesPerElement;
+  // set up integration rule and relevant maps for scs
+  set_interior_info();
+
+  // set up integration rule and relevant maps for faces
+  set_boundary_info();
+
+  // compute and save shape functions and derivatives at ips
+  shapeFunctions_ = elem_.eval_basis_weights(intgLoc_);
+  shapeDerivs_ = elem_.eval_deriv_weights(intgLoc_);
+  expFaceShapeDerivs_ = elem_.eval_deriv_weights(intgExpFace_);
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderQuad2DSCS::set_interior_info()
+{
+  const int linesPerDirection = elem_.nodes1D - 1;
+  const int ipsPerLine = elem_.numQuad * elem_.nodes1D;
+  const int numLines = linesPerDirection * nDim_;
+
+  numIntPoints_ = numLines * ipsPerLine;
+
+  // define L/R mappings
+  lrscv_.resize(2*numIntPoints_);
+
+  // standard integration location
+  intgLoc_.resize(numIntPoints_*nDim_);
+
+  // shifted
+  intgLocShift_.resize(numIntPoints_*nDim_);
+
+  ipInfo_.resize(numIntPoints_);
+
+  // specify integration point locations in a dimension-by-dimension manner
+
+  //u-direction
+  int vector_index = 0;
+  int lrscv_index = 0;
+  int scalar_index = 0;
+  for (int m = 0; m < linesPerDirection; ++m) {
+    for (unsigned l = 0; l < elem_.nodes1D; ++l) {
+
+      int leftNode;
+      int rightNode;
+      int orientation;
+      if (m % 2 == 0) {
+        leftNode  = elem_.tensor_product_node_map(l,m);
+        rightNode = elem_.tensor_product_node_map(l,m + 1);
+        orientation = -1.0;
+      }
+      else {
+        leftNode  = elem_.tensor_product_node_map(l,m + 1);
+        rightNode = elem_.tensor_product_node_map(l,m);
+        orientation = +1.0;
+      }
+
+      for (unsigned j = 0; j < elem_.numQuad; ++j) {
+
+        lrscv_[lrscv_index] = leftNode;
+        lrscv_[lrscv_index + 1] = rightNode;
+
+        intgLoc_[vector_index] = elem_.gauss_point_location(l,j);
+        intgLoc_[vector_index + 1] = elem_.scsLoc[m];
+
+        //compute the quadrature weight
+        ipInfo_[scalar_index].weight = orientation*elem_.tensor_product_weight(l,j);
+
+        //direction
+        ipInfo_[scalar_index].direction = Jacobian::T_DIRECTION;
+
+        ++scalar_index;
+        lrscv_index += 2;
+        vector_index += nDim_;
+      }
+    }
+  }
+
+  //t-direction
+  for (int m = 0; m < linesPerDirection; ++m) {
+    for (unsigned l = 0; l < elem_.nodes1D; ++l) {
+
+      int leftNode;
+      int rightNode;
+      int orientation;
+      if (m % 2 == 0) {
+        leftNode  = elem_.tensor_product_node_map(m,l);
+        rightNode = elem_.tensor_product_node_map(m+1,l);
+        orientation = +1.0;
+      }
+      else {
+        leftNode  = elem_.tensor_product_node_map(m+1,l);
+        rightNode = elem_.tensor_product_node_map(m,l);
+        orientation = -1.0;
+      }
+
+      for (unsigned j = 0; j < elem_.numQuad; ++j) {
+
+        lrscv_[lrscv_index]   = leftNode;
+        lrscv_[lrscv_index+1] = rightNode;
+
+        intgLoc_[vector_index] = elem_.scsLoc[m];
+        intgLoc_[vector_index+1] = elem_.gauss_point_location(l,j);
+
+        //compute the quadrature weight
+        ipInfo_[scalar_index].weight = orientation*elem_.tensor_product_weight(l,j);
+
+        //direction
+        ipInfo_[scalar_index].direction = Jacobian::S_DIRECTION;
+
+        ++scalar_index;
+        lrscv_index += 2;
+        vector_index += nDim_;
+      }
+    }
+  }
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderQuad2DSCS::set_boundary_info()
+{
+  const int numFaces = 2*nDim_;
+  const int nodesPerFace = elem_.nodes1D;
+  const int linesPerDirection = elem_.nodes1D-1;
+  ipsPerFace_ = nodesPerFace*elem_.numQuad;
+
+  const int numFaceIps = numFaces*ipsPerFace_;
+
+  oppFace_.resize(numFaceIps);
+  ipNodeMap_.resize(numFaceIps);
+  oppNode_.resize(numFaceIps);
+  intgExpFace_.resize(numFaceIps*nDim_);
+
+  auto faceMap = elem_.faceNodeMap;
+  auto nodeMap = elem_.nodeMap;
+  auto nodeMap1D = elem_.nodeMapBC;
+
+  auto face_node_number = [&] (int number,int faceOrdinal)
+  {
+    return elem_.faceNodeMap[faceOrdinal][number];
+  };
+
+  const std::array<int, 4> faceToLine = {{
+      0,
+      2*linesPerDirection-1,
+      linesPerDirection-1,
+      linesPerDirection
+  }};
+
+  const std::array<double, 4> faceLoc = {{-1.0, +1.0, +1.0, -1.0}};
+
+  int scalar_index = 0; int vector_index = 0;
+  int faceOrdinal = 0; //bottom face
+  int oppFaceIndex = 0;
+  for (unsigned k = 0; k < elem_.nodes1D; ++k) {
+    const int nearNode = face_node_number(k,faceOrdinal);
+    int oppNode = elem_.tensor_product_node_map(k, 1);
+
+    for (unsigned j = 0; j < elem_.numQuad; ++j) {
+      ipNodeMap_[scalar_index] = nearNode;
+      oppNode_[scalar_index] = oppNode;
+      oppFace_[scalar_index] = oppFaceIndex + faceToLine[faceOrdinal]*ipsPerFace_;
+
+      intgExpFace_[vector_index]   = intgLoc_[oppFace_[scalar_index]*nDim_+0];
+      intgExpFace_[vector_index+1] = faceLoc[faceOrdinal];
+
+      ++scalar_index;
+      vector_index += nDim_;
+      ++oppFaceIndex;
+    }
+  }
+
+  faceOrdinal = 1; //right face
+  oppFaceIndex = 0;
+  for (unsigned k = 0; k < elem_.nodes1D; ++k) {
+    const int nearNode = face_node_number(k,faceOrdinal);
+    int oppNode = elem_.tensor_product_node_map(elem_.nodes1D-2,k);
+
+    for (unsigned j = 0; j < elem_.numQuad; ++j) {
+      ipNodeMap_[scalar_index] = nearNode;
+      oppNode_[scalar_index] = oppNode;
+      oppFace_[scalar_index] = oppFaceIndex + faceToLine[faceOrdinal]*ipsPerFace_;
+
+      intgExpFace_[vector_index]   = faceLoc[faceOrdinal];
+      intgExpFace_[vector_index+1] = intgLoc_[oppFace_[scalar_index]*nDim_+1];
+
+      ++scalar_index;
+      vector_index += nDim_;
+      ++oppFaceIndex;
+    }
+  }
+
+
+  faceOrdinal = 2; //top face
+  oppFaceIndex = 0;
+  //NOTE: this face is reversed
+  int elemNodeM1 = static_cast<int>(elem_.nodes1D-1);
+  for (int k = elemNodeM1; k >= 0; --k) {
+    const int nearNode = face_node_number(elem_.nodes1D-k-1,faceOrdinal);
+    int oppNode = elem_.tensor_product_node_map(k, elem_.nodes1D-2);
+    for (unsigned j = 0; j < elem_.numQuad; ++j) {
+      ipNodeMap_[scalar_index] = nearNode;
+      oppNode_[scalar_index] = oppNode;
+      oppFace_[scalar_index] = (ipsPerFace_-1) - oppFaceIndex + faceToLine[faceOrdinal]*ipsPerFace_;
+
+      intgExpFace_[vector_index] = intgLoc_[oppFace_[scalar_index]*nDim_+0];
+      intgExpFace_[vector_index+1] = faceLoc[faceOrdinal];
+
+      ++scalar_index;
+      vector_index += nDim_;
+      ++oppFaceIndex;
+    }
+  }
+
+  faceOrdinal = 3; //left face
+  oppFaceIndex = 0;
+  //NOTE: this face is reversed
+  for (int k = elemNodeM1; k >= 0; --k) {
+    const int nearNode = face_node_number(elem_.nodes1D-k-1,faceOrdinal);
+    int oppNode = elem_.tensor_product_node_map(1,k);
+    for (unsigned j = 0; j < elem_.numQuad; ++j) {
+      ipNodeMap_[scalar_index] = nearNode;
+      oppNode_[scalar_index] = oppNode;
+      oppFace_[scalar_index] = (ipsPerFace_-1) - oppFaceIndex + faceToLine[faceOrdinal]*ipsPerFace_;
+
+      intgExpFace_[vector_index]   = faceLoc[faceOrdinal];
+      intgExpFace_[vector_index+1] = intgLoc_[oppFace_[scalar_index]*nDim_+1];
+
+      ++scalar_index;
+      vector_index += nDim_;
+      ++oppFaceIndex;
+    }
+  }
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderQuad2DSCS::shape_fcn(double *shpfc)
+{
+  int numShape = shapeFunctions_.size();
+  for (int j = 0; j < numShape; ++j) {
+    shpfc[j] = shapeFunctions_[j];
+  }
+}
+//--------------------------------------------------------------------------
+const int *
+HigherOrderQuad2DSCS::ipNodeMap(int ordinal)
+{
+  // define ip->node mappings for each face (ordinal);
+  return &ipNodeMap_[ordinal*ipsPerFace_];
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderQuad2DSCS::determinant(
+  const int nelem,
+  const double *coords,
+  double *areav,
+  double *error)
+{
+  //returns the normal vector (dyds,-dxds) for constant t curves
+  //returns the normal vector (dydt,-dxdt) for constant s curves
+
+  std::array<double, 2> areaVector;
+
+  for (int k = 0; k < nelem; ++k) {
+    const int coord_elem_offset = nDim_ * nodesPerElement_ * k;
+    const int vector_elem_offset = nDim_*numIntPoints_*k;
+
+    for (int ip = 0; ip < numIntPoints_; ++ip) {
+      const int grad_offset = nDim_ * nodesPerElement_ * ip;
+      const int offset = nDim_ * ip + vector_elem_offset;
+
+      //compute area vector for this ip
+      area_vector( ipInfo_[ip].direction,
+                   &coords[coord_elem_offset],
+                   &shapeDerivs_[grad_offset],
+                   areaVector );
+
+      // apply quadrature weight and orientation (combined as weight)
+      for (int j = 0; j < nDim_; ++j) {
+        areav[offset+j]  = ipInfo_[ip].weight * areaVector[j];
+      }
+    }
+  }
+
+  *error = 0;
+}
+//--------------------------------------------------------------------------
+void HigherOrderQuad2DSCS::grad_op(
+  const int nelem,
+  const double *coords,
+  double *gradop,
+  double *deriv,
+  double *det_j,
+  double *error)
+{
+  *error = 0.0;
+
+  for (int k = 0; k < nelem; ++k) {
+    const int coord_elem_offset = nDim_ * nodesPerElement_ * k;
+    const int scalar_elem_offset = numIntPoints_ * k;
+    const int grad_elem_offset = numIntPoints_ * nDim_ * nodesPerElement_ * k;
+
+    for (int ip = 0; ip < numIntPoints_; ++ip) {
+      const int grad_offset = nDim_ * nodesPerElement_ * ip;
+      const int offset = grad_offset + grad_elem_offset;
+
+      for (int j = 0; j < nodesPerElement_ * nDim_; ++j) {
+        deriv[offset + j] = shapeDerivs_[grad_offset +j];
+      }
+
+      gradient( &coords[coord_elem_offset],
+                &shapeDerivs_[grad_offset],
+                &gradop[offset],
+                &det_j[scalar_elem_offset+ip] );
+
+      if (det_j[ip] <= 0.0) {
+        *error = 1.0;
+      }
+    }
+  }
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderQuad2DSCS::face_grad_op(
+  const int nelem,
+  const int face_ordinal,
+  const double *coords,
+  double *gradop,
+  double *det_j,
+  double *error)
+{
+  *error = 0.0;
+
+  const int face_offset =  nDim_ * ipsPerFace_ * nodesPerElement_ * face_ordinal;
+  for (int k = 0; k < nelem; ++k) {
+    const int coord_elem_offset = nDim_ * nodesPerElement_ * k;
+    const int scalar_elem_offset = ipsPerFace_ * k;
+    const int grad_elem_offset = ipsPerFace_ * nDim_ * nodesPerElement_ * k;
+
+    for (int ip = 0; ip < ipsPerFace_; ++ip) {
+      const int grad_offset = nDim_ * nodesPerElement_ * ip;
+      const int offset = grad_offset + grad_elem_offset;
+
+      gradient( &coords[coord_elem_offset],
+                &expFaceShapeDerivs_[face_offset+grad_offset],
+                &gradop[offset],
+                &det_j[scalar_elem_offset+ip] );
+
+      if (det_j[ip] <= 0.0) {
+        *error = 1.0;
+      }
+    }
+  }
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderQuad2DSCS::gradient(
+  const double* elemNodalCoords,
+  const double* shapeDeriv,
+  double* grad,
+  double* det_j) const
+{
+  double dx_ds1 = 0.0;  double dx_ds2 = 0.0;
+  double dy_ds1 = 0.0;  double dy_ds2 = 0.0;
+
+  //compute Jacobian
+  for (int node = 0; node < nodesPerElement_; ++node) {
+    const int vector_offset = nDim_ * node;
+
+    const double xCoord = elemNodalCoords[vector_offset + 0];
+    const double yCoord = elemNodalCoords[vector_offset + 1];
+    const double dn_ds1 = shapeDeriv[vector_offset + 0];
+    const double dn_ds2 = shapeDeriv[vector_offset + 1];
+
+    dx_ds1 += dn_ds1 * xCoord;
+    dx_ds2 += dn_ds2 * xCoord;
+
+    dy_ds1 += dn_ds1 * yCoord;
+    dy_ds2 += dn_ds2 * yCoord;
+  }
+
+  *det_j = dx_ds1*dy_ds2 - dy_ds1*dx_ds2;
+
+  const double inv_det_j = (*det_j > 0.0) ? 1.0 / (*det_j) : 0.0;
+
+  const double ds1_dx =  inv_det_j*dy_ds2;
+  const double ds2_dx = -inv_det_j*dy_ds1;
+
+  const double ds1_dy = -inv_det_j*dx_ds2;
+  const double ds2_dy =  inv_det_j*dx_ds1;
+
+  for (int node = 0; node < nodesPerElement_; ++node) {
+    const int vector_offset = nDim_ * node;
+
+    const double dn_ds1 = shapeDeriv[vector_offset + 0];
+    const double dn_ds2 = shapeDeriv[vector_offset + 1];
+
+    grad[vector_offset + 0] = dn_ds1 * ds1_dx + dn_ds2 * ds2_dx;
+    grad[vector_offset + 1] = dn_ds1 * ds1_dy + dn_ds2 * ds2_dy;
+  }
+}
+//--------------------------------------------------------------------------
+const int *
+HigherOrderQuad2DSCS::adjacentNodes()
+{
+  // define L/R mappings
+  return &lrscv_[0];
+}
+//--------------------------------------------------------------------------
+int
+HigherOrderQuad2DSCS::opposingNodes(
+  const int ordinal,
+  const int node)
+{
+  return oppNode_[ordinal*ipsPerFace_+node];
+}
+//--------------------------------------------------------------------------
+int
+HigherOrderQuad2DSCS::opposingFace(
+  const int ordinal,
+  const int node)
+{
+  return oppFace_[ordinal*ipsPerFace_+node];
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderQuad2DSCS::area_vector(
+  const Jacobian::Direction direction,
+  const double *elemNodalCoords,
+  const double *shapeDeriv,
+  std::array<double,2>& areaVector ) const
+{
+  int s1Component;
+  switch (direction) {
+    case Jacobian::S_DIRECTION:
+      s1Component = static_cast<int>(Jacobian::T_DIRECTION);
+      break;
+    case Jacobian::T_DIRECTION:
+      s1Component = static_cast<int>(Jacobian::S_DIRECTION);
+      break;
+    default:
+      throw std::runtime_error("Not a valid direction for this element!");
+  }
+
+  double dxdr = 0.0;  double dydr = 0.0;
+  for (int node = 0; node < nodesPerElement_; ++node) {
+    const int vector_offset = nDim_ * node;
+    const double xCoord = elemNodalCoords[vector_offset+0];
+    const double yCoord = elemNodalCoords[vector_offset+1];
+
+    dxdr += shapeDeriv[vector_offset+s1Component] * xCoord;
+    dydr += shapeDeriv[vector_offset+s1Component] * yCoord;
+  }
+  areaVector[0] =  dydr;
+  areaVector[1] = -dxdr;
+}
+//--------------------------------------------------------------------------
+void HigherOrderQuad2DSCS::gij(
+  const double *coords,
+  double *gupperij,
+  double *glowerij,
+  double *deriv)
+{
+  SIERRA_FORTRAN(twod_gij)
+    ( &nodesPerElement_,
+      &numIntPoints_,
+      deriv,
+      coords, gupperij, glowerij);
+}
+//--------------------------------------------------------------------------
+HigherOrderEdge2DSCS::HigherOrderEdge2DSCS(const ElementDescription& elem)
+: MasterElement(),
+  elem_(elem)
+{
+  nDim_ = 2;
+  nodesPerElement_ = elem_.nodes1D;
+  numIntPoints_ = elem_.numQuad * elem_.nodes1D;
+
+  ipNodeMap_.resize(numIntPoints_);
+  intgLoc_.resize(numIntPoints_);
+
+  ipWeight_.resize(numIntPoints_);
+
+  int scalar_index = 0;
+  for (unsigned k = 0; k < elem_.nodes1D; ++k) {
+    for (unsigned i = 0; i < elem_.numQuad; ++i) {
+      intgLoc_[scalar_index]  = elem_.gauss_point_location(k,i);
+      ipWeight_[scalar_index] = elem_.tensor_product_weight(k,i);
+      ipNodeMap_[scalar_index] = elem_.tensor_product_node_map(k);
+      ++scalar_index;
+    }
+  }
+
+  shapeFunctions_ = elem_.basisBoundary->eval_basis_weights(intgLoc_);
+  shapeDerivs_ = elem_.basisBoundary->eval_deriv_weights(intgLoc_);
+}
+//--------------------------------------------------------------------------
+const int *
+HigherOrderEdge2DSCS::ipNodeMap(int /*ordinal*/)
+{
+  return &ipNodeMap_[0];
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderEdge2DSCS::determinant(
+  const int nelem,
+  const double *coords,
+  double *areav,
+  double *error)
+{
+  std::array<double,2> areaVector;
+
+  for (int k = 0; k < nelem; ++k) {
+    const int coord_elem_offset = nDim_ * nodesPerElement_ * k;
+
+    for (int ip = 0; ip < numIntPoints_; ++ip) {
+      const int offset = nDim_ * ip + coord_elem_offset;
+      const int grad_offset = ip * nodesPerElement_; // times edgeDim = 1
+
+      // calculate the area vector
+      area_vector( &coords[coord_elem_offset],
+                   &shapeDerivs_[grad_offset],
+                   areaVector );
+
+      // weight the area vector with the Gauss-quadrature weight for this IP
+      areav[offset + 0] = ipWeight_[ip] * areaVector[0];
+      areav[offset + 1] = ipWeight_[ip] * areaVector[1];
+    }
+  }
+
+  // check
+  *error = 0.0;
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderEdge2DSCS::shape_fcn(double *shpfc)
+{
+  int numShape = shapeFunctions_.size();
+   for (int j = 0; j < numShape; ++j) {
+     shpfc[j] = shapeFunctions_[j];
+   }
+}
+//--------------------------------------------------------------------------
+void
+HigherOrderEdge2DSCS::area_vector(
+  const double* elemNodalCoords,
+  const double* shapeDeriv,
+  std::array<double,2>& areaVector) const
+{
+  double dxdr = 0.0;  double dydr = 0.0;
+  for (int node = 0; node < nodesPerElement_; ++node) {
+    const int vector_offset = nDim_ * node;
+    const double xCoord = elemNodalCoords[vector_offset+0];
+    const double yCoord = elemNodalCoords[vector_offset+1];
+
+    dxdr += shapeDeriv[node] * xCoord;
+    dydr += shapeDeriv[node] * yCoord;
+  }
+  areaVector[0] =  dydr;
+  areaVector[1] = -dxdr;
+}
+
+}  // namespace nalu
+} // namespace sierra

--- a/src/element_promotion/PromoteElement.C
+++ b/src/element_promotion/PromoteElement.C
@@ -1,0 +1,931 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+#include <element_promotion/PromoteElement.h>
+
+#include <element_promotion/ElementDescription.h>
+#include <element_promotion/FaceOperations.h>
+#include <NaluEnv.h>
+
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Selector.hpp>
+#include <stk_util/parallel/CommSparse.hpp>
+#include <stk_mesh/base/Bucket.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/FieldBase.hpp>
+#include <stk_topology/topology.hpp>
+#include <stk_util/environment/ReportHandler.hpp>
+#include <stk_util/parallel/ParallelComm.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <iostream>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace sierra{
+namespace nalu{
+
+  std::string promote_part_name(const std::string& base_name)
+  {
+    return (base_name+"_promoted");
+  }
+
+  stk::mesh::Part* promoted_part(const stk::mesh::Part& part) {
+    auto promotedName = promote_part_name(part.name());
+    return (part.mesh_meta_data().get_part(promotedName));
+  }
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// PromoteElement - Promotes a mesh based on a description of the new element
+// connectivities and node locations
+// TODO(rcknaus): allow some parts not to be promoted
+//===============================c===========================================
+PromoteElement::PromoteElement(ElementDescription& elemDescription)
+: elemDescription_(elemDescription),
+  nodesPerElement_(elemDescription.nodesPerElement),
+  dimension_(elemDescription.dimension)
+{
+ //do nothing
+}
+//--------------------------------------------------------------------------
+size_t PromoteElement::num_elems(const stk::mesh::Entity& node) const
+{
+  return (nodeElemMap_.at(node).size());
+}
+//--------------------------------------------------------------------------
+size_t PromoteElement::num_nodes(const stk::mesh::Entity& elem) const
+{
+  return (elemNodeMap_.at(elem).size());
+}
+//--------------------------------------------------------------------------
+stk::mesh::Entity const*
+PromoteElement::begin_nodes_all(const stk::mesh::Bucket& bucket,
+  stk::mesh::EntityId id) const
+{
+  return (elemNodeMap_.at(bucket[id]).data());
+}
+//--------------------------------------------------------------------------
+stk::mesh::Entity const*
+PromoteElement::begin_nodes_all(const stk::mesh::Entity& elem) const
+{
+  return (elemNodeMap_.at(elem).data());
+}
+//--------------------------------------------------------------------------
+stk::mesh::Entity const*
+PromoteElement::begin_elems_all(const stk::mesh::Bucket& bucket,
+  stk::mesh::EntityId id) const
+{
+  return (nodeElemMap_.at(bucket[id]).data());
+}
+//--------------------------------------------------------------------------
+stk::mesh::Entity const*
+PromoteElement::begin_elems_all(const stk::mesh::Entity& elem) const
+{
+  return (nodeElemMap_.at(elem).data());
+}
+//--------------------------------------------------------------------------
+stk::mesh::Entity const*
+PromoteElement::begin_side_elems_all(const stk::mesh::Bucket& bucket,
+  stk::mesh::EntityId id) const
+{
+  return (nodeElemMapBC_.at(bucket[id]).data());
+}
+//--------------------------------------------------------------------------
+stk::mesh::Entity const*
+PromoteElement::begin_side_elems_all(const stk::mesh::Entity& elem) const
+{
+  return (nodeElemMapBC_.at(elem).data());
+}
+//--------------------------------------------------------------------------
+void
+PromoteElement::promote_elements(
+  const stk::mesh::PartVector& baseParts,
+  VectorFieldType& coordinates,
+  stk::mesh::BulkData& mesh,
+  stk::mesh::PartVector& promotedParts)
+{
+  ThrowRequireMsg(mesh.in_modifiable_state(),
+    "Mesh must be in a modifiable state for element promotion");
+
+  baseParts_ = baseParts; // holds the original elements and original nodes
+  promotedParts_ = promotedParts; // holds only the new nodes (
+
+  auto basePartSelector = stk::mesh::selectUnion(baseParts);
+
+  auto nodeRequests = create_child_node_requests(mesh, elemDescription_,
+    basePartSelector);
+
+  batch_create_child_nodes(mesh, nodeRequests, baseParts);
+
+  populate_elem_node_relations(elemDescription_, mesh, basePartSelector,
+    nodeRequests);
+
+  if (dimension_ == 2) {
+    set_new_node_coords<2>(coordinates, elemDescription_, mesh, nodeRequests);
+  }
+  else {
+    set_new_node_coords<3>(coordinates, elemDescription_, mesh, nodeRequests);
+  }
+
+  elemNodeMap_.rehash(elemNodeMap_.size());
+  nodeElemMap_.rehash(nodeElemMap_.size());
+}
+//--------------------------------------------------------------------------
+PromoteElement::NodeRequests
+PromoteElement::create_child_node_requests(
+  stk::mesh::BulkData& mesh,
+  const ElementDescription& elemDescription,
+  const stk::mesh::Selector& selector) const
+{
+  // Creates a list of nodes to be created by the batch_create_child_nodes method.
+  // Saves off a list of elements sharing the added nodes as well as the ordinal
+  // the new node should have for each element it is associated with
+  const stk::mesh::BucketVector& elem_buckets = mesh.get_buckets(
+    stk::topology::ELEM_RANK, selector);
+
+  const auto& connectivities = elemDescription.addedConnectivities;
+  const size_t num_relations = connectivities.size();
+
+  // pre-size parentIds
+  std::vector<std::vector<stk::mesh::EntityId>> parentIds(num_relations);
+  size_t countRels = 0;
+  for (const auto& relation : connectivities) {
+    parentIds[countRels].resize(relation.second.size());
+    ++countRels;
+  }
+
+  NodeRequests requestSet;
+  for (const auto* ib : elem_buckets) {
+    const stk::mesh::Bucket& b = *ib;
+    const stk::mesh::Bucket::size_type length = b.size();
+    for (stk::mesh::Bucket::size_type k = 0; k < length; ++k) {
+      const auto& elem = b[k];
+      const stk::mesh::Entity* nodes = b.begin_nodes(k);
+      size_t relationCount = 0;
+      for (const auto& relation : connectivities) {
+        const auto& parentOrdinals = relation.second;
+        for (size_t j = 0; j < parentOrdinals.size(); ++j) {
+          parentIds[relationCount][j] = mesh.identifier(nodes[parentOrdinals[j]]);
+        }
+
+        const auto unsortedParentIds = parentIds[relationCount];
+        std::sort(
+          parentIds[relationCount].begin(),
+          parentIds[relationCount].end()
+        );
+
+        auto result =
+            requestSet.insert(ChildNodeRequest{ parentIds[relationCount] });
+        result.first->add_shared_elem(elem); // add a shared elem regardless
+        if (result.second) {
+          result.first->set_num_children(relation.first.size());
+          result.first->unsortedParentIds_ = std::move(unsortedParentIds);
+        }
+        ++relationCount;
+      }
+    }
+  }
+
+  //FIXME(rcknaus): clean-up the ordinal reversing logic
+
+  // For P>2, we have to worry about whether an edge is ordered forward or backward
+  // The locations map expects things to be ordered, so we keep them sorted
+  // and the node locations are reversed in elemNodeMap.
+  unsigned nodes1D = elemDescription.nodes1D;
+  unsigned numAddedNodes1D = nodes1D-2;
+  unsigned numParents1D = nodes1D-numAddedNodes1D; //2
+  for (auto& request : requestSet) {
+    unsigned numShared = request.sharedElems_.size();
+    request.childOrdinalsForElem_.resize(numShared);
+    request.reorderedChildOrdinalsForElem_.resize(numShared);
+    for (unsigned elemNumber = 0; elemNumber < numShared; ++elemNumber) {
+      const auto unsortedOrdinals =
+          request.determine_child_node_ordinal(mesh, elemDescription, elemNumber);
+      const auto& ordinals = request.childOrdinalsForElem_[elemNumber];
+      const auto& canonicalOrdinals = elemDescription.addedConnectivities.at(ordinals);
+
+      request.reorderedChildOrdinalsForElem_[elemNumber] = reorder_ordinals<size_t>(
+        ordinals,
+        unsortedOrdinals,
+        canonicalOrdinals,
+        numParents1D,
+        numAddedNodes1D
+      );
+    }
+  }
+
+  return requestSet;
+}
+//--------------------------------------------------------------------------
+void
+PromoteElement::batch_create_child_nodes(
+  stk::mesh::BulkData& mesh,
+  NodeRequests& requests,
+  const stk::mesh::PartVector& node_parts) const
+{
+  size_t num_nodes_requested = count_requested_nodes(requests);
+  std::vector<stk::mesh::EntityId> available_node_ids(num_nodes_requested);
+  mesh.generate_new_ids(stk::topology::NODE_RANK, num_nodes_requested,
+    available_node_ids);
+
+  size_t it_req = 0;
+  for (auto& request : requests) {
+    for (unsigned j = 0; j < request.num_children(); ++j, ++it_req) {
+      request.add_proc_id_pair(
+        mesh.parallel_rank(), available_node_ids[it_req], j
+      );
+    }
+    request.determine_sharing_procs(mesh);
+  }
+
+  if (mesh.parallel_size() > 1) {
+    parallel_communicate_ids(mesh, requests);
+  }
+
+  for (auto& request : requests) {
+     request.set_node_entity_for_request(mesh, node_parts);
+  }
+}
+//--------------------------------------------------------------------------
+void
+PromoteElement::parallel_communicate_ids(
+  const stk::mesh::BulkData& mesh, NodeRequests& requests) const
+{
+  stk::CommSparse comm_spec(mesh.parallel());
+
+  for (int phase = 0; phase < 2; ++phase) {
+    for (const auto& request : requests) {
+      for (auto other_proc : request.sharingProcs_) {
+        if (other_proc != mesh.parallel_rank()) {
+          const auto& request_parents = request.unsortedParentIds_;
+          const auto numChildren = request.num_children();
+          comm_spec.send_buffer(other_proc).pack(request.num_parents());
+          comm_spec.send_buffer(other_proc).pack(numChildren);
+          for (auto parentId : request_parents) {
+            comm_spec.send_buffer(other_proc).pack(parentId);
+          }
+
+          for (unsigned j = 0; j < numChildren; ++j) {
+            comm_spec.send_buffer(other_proc).pack(
+              request.suggested_node_id(j));
+          }
+        }
+      }
+    }
+
+    if (phase == 0) {
+      comm_spec.allocate_buffers();
+    }
+    else {
+      comm_spec.communicate();
+    }
+  }
+
+  unsigned numAddedNodes1D = elemDescription_.nodes1D-2;
+  for (int i = 0; i < mesh.parallel_size(); ++i) {
+    if (i != mesh.parallel_rank()) {
+      while (comm_spec.recv_buffer(i).remaining() != 0) {
+
+        size_t num_parents;
+        size_t num_children;
+        stk::mesh::EntityId suggested_node_id;
+        comm_spec.recv_buffer(i).unpack(num_parents);
+        comm_spec.recv_buffer(i).unpack(num_children);
+        std::vector<stk::mesh::EntityId> parentIds(num_parents);
+
+        for (auto& parentId : parentIds) {
+          comm_spec.recv_buffer(i).unpack(parentId);
+        }
+
+        std::vector<size_t> indices;
+        auto sortedParentIds = parentIds;
+        std::sort(sortedParentIds.begin(),sortedParentIds.end());
+        auto iter = requests.find(ChildNodeRequest{std::move(sortedParentIds)});
+        bool hasParents = iter != requests.end();
+
+        if (hasParents) {
+          indices.resize(num_children);
+          std::iota(indices.begin(), indices.end(), 0);
+
+          // nodes are compared against a single set of parent ordinals
+          // for edges, the sorted parent ordinals still form a chain and can be used,
+          // making the ordinals parallel consistent by construction
+
+          // For faces/volumes, I use the fact that the ordinals are not randomly ordered
+          // so I can't just use the sorted parentIds atm and have to enforce parallel consistency
+          // by sending over the reference parentIds and then match indices with the ordinals to ensure
+          // consistent global node ids in parallel
+
+          if (num_children == numAddedNodes1D*numAddedNodes1D && dimension_ == 3) {
+            auto request = *iter;
+            unsigned elemNumber = 0u;
+            unsigned numParents1D = 2;
+
+            // lower rank processes lead
+            if (i < mesh.parallel_rank()) {
+              request.unsortedParentIds_ = parentIds;
+            }
+            const auto unsortedOrdinals =
+                request.determine_child_node_ordinal(mesh, elemDescription_, elemNumber);
+            const auto& canonicalOrdinals =
+                elemDescription_.addedConnectivities.at(
+                  request.childOrdinalsForElem_[0]);
+
+            indices = reorder_ordinals<size_t>(
+              indices,
+              unsortedOrdinals,
+              canonicalOrdinals,
+              numParents1D,
+              numAddedNodes1D
+            );
+          }
+        }
+
+        for (unsigned j = 0; j < num_children; ++j) {
+          comm_spec.recv_buffer(i).unpack(suggested_node_id);
+          if (hasParents) {
+            iter->add_proc_id_pair(i, suggested_node_id, indices[j]);
+          }
+        }
+      }
+    }
+  }
+}
+//--------------------------------------------------------------------------
+void
+PromoteElement::populate_elem_node_relations(
+  const ElementDescription& elemDescription, stk::mesh::BulkData& mesh,
+  const stk::mesh::Selector selector, const NodeRequests& requests)
+{
+  const stk::mesh::BucketVector& elem_buckets = mesh.get_buckets(
+    stk::topology::ELEM_RANK, selector);
+  const stk::mesh::BucketVector& node_buckets = mesh.get_buckets(
+    stk::topology::NODE_RANK, selector);
+
+  elemNodeMap_.reserve(count_entities(elem_buckets));
+  nodeElemMap_.reserve(count_requested_nodes(requests));
+
+  // initialize base downward relationships
+  for (const auto* ib : elem_buckets) {
+    const stk::mesh::Bucket& b = *ib;
+    const stk::mesh::Bucket::size_type length = b.size();
+    for (stk::mesh::Bucket::size_type k = 0; k < length; ++k) {
+      const stk::mesh::Entity elem = b[k];
+      const stk::mesh::Entity* nodes = b.begin_nodes(k);
+      elemNodeMap_[elem].resize(nodesPerElement_);
+      for (size_t j = 0; j < b.num_nodes(k); ++j) {
+        elemNodeMap_[elem][j] = nodes[j];
+      }
+    }
+  }
+
+  // initialize base upward relationships
+  for (const auto* ib : node_buckets) {
+    const stk::mesh::Bucket& b = *ib;
+    const stk::mesh::Bucket::size_type length = b.size();
+    for (stk::mesh::Bucket::size_type k = 0; k < length; ++k) {
+      const stk::mesh::Entity node = b[k];
+      const stk::mesh::Entity* elem_rels = b.begin_elements(k);
+      const size_t num_elems = b.num_elements(k);
+      std::vector<stk::mesh::Entity> elemList(num_elems);
+      nodeElemMap_.insert({ node, elemList });
+      for (size_t j = 0; j < b.num_elements(k); ++j) {
+        nodeElemMap_.at(node)[j] = elem_rels[j];
+      }
+    }
+  }
+
+  unsigned nodes1D = elemDescription.nodes1D;
+  for (const auto& request : requests) {
+    unsigned numShared = request.sharedElems_.size();
+    for (unsigned elemNumber = 0; elemNumber < numShared; ++elemNumber) {
+      auto sharedElem = request.sharedElems_[elemNumber];
+      auto& ordinals = request.reorderedChildOrdinalsForElem_[elemNumber];
+
+      for (unsigned j = 0; j < request.num_children(); ++j) {
+        elemNodeMap_.at(sharedElem)[ordinals[j]] = request.children_[j];
+      }
+    }
+    for (const auto child : request.children_) {
+      nodeElemMap_.insert({ child, request.sharedElems_ });
+    }
+  }
+
+  // Boundaries
+    auto topo = (dimension_ == 2) ?
+        stk::topology::EDGE_RANK : stk::topology::FACE_RANK;
+    const stk::mesh::BucketVector& boundary_buckets = mesh.get_buckets(
+      topo, selector);
+
+    nodeElemMapBC_.reserve(
+      count_entities(boundary_buckets)*elemDescription_.nodes1D
+    );
+
+    std::vector<stk::mesh::Entity> faceNodes(std::pow(nodes1D,dimension_-1));
+    for (const auto* ib : boundary_buckets) {
+      const stk::mesh::Bucket& b = *ib;
+      const stk::mesh::Bucket::size_type length = b.size();
+
+      for (stk::mesh::Bucket::size_type k = 0; k < length; ++k) {
+        const auto face = b[k];
+
+        const auto* parent_elems = mesh.begin_elements(face);
+        ThrowAssert(mesh.num_elements(face) == 1);
+
+        const auto* face_elem_ords = mesh.begin_element_ordinals(face);
+        const unsigned face_ordinal = face_elem_ords[0];
+        const auto elem_node_rels = elemNodeMap_.at(parent_elems[0]);
+        const auto& nodeOrdinalsForFace = elemDescription_.faceNodeMap[face_ordinal];
+
+        if (dimension_ == 2) {
+          for (unsigned j = 0; j < nodes1D; ++j) {
+            int ordinal = elemDescription_.tensor_product_node_map(j);
+            faceNodes[ordinal] = elem_node_rels[nodeOrdinalsForFace[j]];
+          }
+        }
+        else {
+          for (unsigned j = 0; j < nodes1D; ++j) {
+            for (unsigned i = 0; i < nodes1D; ++i) {
+              int ordinal = elemDescription_.tensor_product_node_map_bc(i,j);;
+              faceNodes[ordinal] = elem_node_rels[nodeOrdinalsForFace[i+nodes1D*j]];
+            }
+          }
+        }
+        elemNodeMap_.insert({face, faceNodes});
+
+        for (auto faceNode : faceNodes) {
+          nodeElemMapBC_.insert({faceNode, {face}});
+        }
+      }
+    }
+
+  ThrowAssert(check_elem_node_relations(mesh));
+}
+//--------------------------------------------------------------------------
+bool
+PromoteElement::check_elem_node_relations(
+  const stk::mesh::BulkData& mesh) const
+{
+  for (const auto& elemNodePair : elemNodeMap_) {
+    for (const auto& node : elemNodePair.second) {
+      if (!(mesh.is_valid(node))) {
+        return false;
+      }
+    }
+  }
+
+  for (const auto& nodeElemPair : nodeElemMap_) {
+    if (nodeElemPair.second.size() < 1) {
+      return false;
+    }
+    for (const auto& elem : nodeElemPair.second) {
+      if (!(mesh.is_valid(elem))) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+//--------------------------------------------------------------------------
+template<unsigned embedding_dimension> void
+PromoteElement::set_new_node_coords(
+  VectorFieldType& coordinates,
+  const ElementDescription& elemDescription,
+  const stk::mesh::BulkData& mesh,
+   NodeRequests& requests) const
+{
+  //  hex/quad specific method for interpolating coordinates
+  static_assert(embedding_dimension == 2 || embedding_dimension == 3,"");
+
+  for (auto& request : requests) {
+    unsigned elemIndex = 0u;
+
+    auto numParents = request.parentIds_.size();
+    const auto& ordinals= request.childOrdinalsForElem_[elemIndex];
+    const auto* node_rels = begin_nodes_all(request.sharedElems_[elemIndex]);
+    const auto& childLocations = elemDescription.locationsForNewNodes.at(ordinals);
+
+    switch (numParents)
+    {
+      case 2:
+      {
+        std::array<stk::mesh::Entity,2> parentNodes;
+        for (unsigned j = 0; j < 2; ++j) {
+          parentNodes[j] = mesh.get_entity(
+            stk::topology::NODE_RANK,
+            request.unsortedParentIds_[j]
+          );
+        }
+
+        set_coords_for_child<embedding_dimension, 1>(
+          coordinates, node_rels,
+          ordinals, parentNodes,
+          childLocations);
+        break;
+      }
+      case 4:
+      {
+        std::array<stk::mesh::Entity,4> parentNodes;
+        for (unsigned j = 0; j < 4; ++j) {
+          parentNodes[j] = mesh.get_entity(
+            stk::topology::NODE_RANK,
+            request.unsortedParentIds_[j]
+          );
+        }
+
+        set_coords_for_child<embedding_dimension, 2>(
+          coordinates, node_rels,
+          ordinals, parentNodes,
+          childLocations);
+        break;
+      }
+      case 8:
+      {
+        std::array<stk::mesh::Entity,8> parentNodes;
+        for (unsigned j = 0; j < 8; ++j) {
+          parentNodes[j] = mesh.get_entity(
+            stk::topology::NODE_RANK,
+            request.unsortedParentIds_[j]
+          );
+        }
+
+        set_coords_for_child<3, 3>(
+          coordinates, node_rels,
+          ordinals, parentNodes,
+          childLocations);
+        break;
+      }
+      default:
+      {
+        throw std::runtime_error("invalid parent number");
+      }
+    }
+  }
+}
+//--------------------------------------------------------------------------
+template<unsigned embedding_dimension, unsigned dimension> void
+PromoteElement::set_coords_for_child(
+  VectorFieldType& coordinates,
+  const stk::mesh::Entity* node_rels,
+  const std::vector<size_t>& childOrdinals,
+  const std::array<stk::mesh::Entity,ipow(2,dimension)>& parentNodes,
+  const std::vector<std::vector<double>>& isoParCoords) const
+{
+  constexpr unsigned numParents = ipow(2,dimension);
+  ThrowAssert(parentNodes.size() == numParents);
+
+  std::array<double*, numParents> parentCoordPtrs;
+  for (unsigned m = 0; m < numParents; ++m) {
+    parentCoordPtrs[m] = static_cast<double*>(stk::mesh::field_data(
+      coordinates, parentNodes[m]
+    ));
+  }
+
+  std::array<double, embedding_dimension * numParents> parentCoords;
+  for (size_t m = 0; m < numParents; ++m) {
+    for (size_t j = 0; j < embedding_dimension; ++j) {
+      parentCoords[j + m * embedding_dimension] = parentCoordPtrs[m][j];
+    }
+  }
+
+  for (unsigned j = 0; j < childOrdinals.size(); ++j) {
+    auto* coords =
+        static_cast<double*>(
+            stk::mesh::field_data(coordinates, node_rels[childOrdinals[j]]
+        )
+    );
+
+    interpolate_coords<embedding_dimension, dimension>(
+      isoParCoords[j],
+      parentCoords,
+      coords
+    );
+  }
+}
+//--------------------------------------------------------------------------
+template<unsigned embedding_dimension, unsigned dimension> void
+PromoteElement::interpolate_coords(
+  const std::vector<double>& isoParCoord,
+  const std::array<double, embedding_dimension*ipow(2,dimension)>& parentCoords,
+  double* interpolatedCoords) const
+{
+  static_assert ( embedding_dimension == 2 || embedding_dimension == 3, "");
+  static_assert ( dimension <= embedding_dimension, "");
+
+  constexpr unsigned num_shape = ipow(2,dimension);
+  std::array<double, num_shape> shape_function;
+
+  auto shape1D = [](double x, double xi) { return 0.5*(1.0+xi*x); };
+  switch (dimension) {
+    case 1:
+    {
+      shape_function[0] = shape1D(isoParCoord[0],-1.0);
+      shape_function[1] = shape1D(isoParCoord[0],+1.0);
+      break;
+    }
+    case 2:
+    {
+      const double s1 = isoParCoord[0];
+      const double s2 = isoParCoord[1];
+      shape_function[0] = shape1D(s1,-1.0)*shape1D(s2,-1.0);
+      shape_function[1] = shape1D(s1,+1.0)*shape1D(s2,-1.0);
+      shape_function[2] = shape1D(s1,+1.0)*shape1D(s2,+1.0);
+      shape_function[3] = shape1D(s1,-1.0)*shape1D(s2,+1.0);
+      break;
+    }
+    case 3:
+    {
+      const double s1 = isoParCoord[0];
+      const double s2 = isoParCoord[1];
+      const double s3 = isoParCoord[2];
+      shape_function[0] = shape1D(s1,-1.0)*shape1D(s2,-1.0)*shape1D(s3,-1.0);
+      shape_function[1] = shape1D(s1,+1.0)*shape1D(s2,-1.0)*shape1D(s3,-1.0);
+      shape_function[2] = shape1D(s1,+1.0)*shape1D(s2,-1.0)*shape1D(s3,+1.0);
+      shape_function[3] = shape1D(s1,-1.0)*shape1D(s2,-1.0)*shape1D(s3,+1.0);
+      shape_function[4] = shape1D(s1,-1.0)*shape1D(s2,+1.0)*shape1D(s3,-1.0);
+      shape_function[5] = shape1D(s1,+1.0)*shape1D(s2,+1.0)*shape1D(s3,-1.0);
+      shape_function[6] = shape1D(s1,+1.0)*shape1D(s2,+1.0)*shape1D(s3,+1.0);
+      shape_function[7] = shape1D(s1,-1.0)*shape1D(s2,+1.0)*shape1D(s3,+1.0);
+      break;
+    }
+  }
+
+  for (unsigned j = 0; j < embedding_dimension; ++j) {
+    interpolatedCoords[j] = 0.0;
+  }
+
+  for (unsigned m = 0; m < num_shape; ++m) {
+    for (unsigned j = 0; j < embedding_dimension; ++j) {
+      interpolatedCoords[j] += shape_function[m] *
+          parentCoords[j + m * embedding_dimension];
+    }
+  }
+}
+//--------------------------------------------------------------------------
+template<typename T> std::vector<T>
+PromoteElement::reorder_ordinals(
+  const std::vector<T>& ordinals,
+  const std::vector<T>& unsortedOrdinals,
+  const std::vector<T>& canonicalOrdinals,
+  unsigned numParents1D,
+  unsigned numAddedNodes1D) const
+{
+  // unnecessary if P < 3
+  if (elemDescription_.polyOrder < 3) {
+    return ordinals;
+  }
+
+  std::vector<T> reorderedOrdinals;
+  if (parents_are_reversed<T>(unsortedOrdinals, canonicalOrdinals)) {
+    reorderedOrdinals = ordinals;
+    std::reverse(reorderedOrdinals.begin(), reorderedOrdinals.end());
+    if(unsortedOrdinals.size() == numParents1D*numParents1D) {
+      reorderedOrdinals = flip_x<T>(reorderedOrdinals, numAddedNodes1D);
+    }
+  }
+  else if (parents_are_flipped_x<T>(unsortedOrdinals, canonicalOrdinals, numParents1D)) {
+    reorderedOrdinals = flip_x<T>(ordinals,numAddedNodes1D);
+  }
+  else if (parents_are_flipped_y<T>(unsortedOrdinals, canonicalOrdinals, numParents1D)) {
+    reorderedOrdinals = flip_y<T>(ordinals,numAddedNodes1D); // never executed AFAIK
+  }
+  else if (should_transpose<T>(unsortedOrdinals, canonicalOrdinals)) {
+    reorderedOrdinals = transpose_ordinals<T>(ordinals,numAddedNodes1D);
+  }
+  else if (should_invert<T>(unsortedOrdinals, canonicalOrdinals)) {
+    reorderedOrdinals = invert_ordinals_yx<T>(ordinals,numAddedNodes1D);
+  }
+  else  {
+    ThrowRequireMsg(unsortedOrdinals == canonicalOrdinals,
+      "Element promotion: unexpected permutation of parent ordinals");
+
+    reorderedOrdinals = ordinals;
+  }
+  return reorderedOrdinals;
+}
+//--------------------------------------------------------------------------
+size_t
+PromoteElement::count_requested_nodes(const NodeRequests& requests) const
+{
+  size_t numNodes = 0;
+  for (const auto& request : requests) {
+    numNodes += request.num_children();
+  }
+  return numNodes;
+}
+//--------------------------------------------------------------------------
+size_t
+PromoteElement::num_sub_elements(
+  const stk::mesh::MetaData& metaData,
+  const stk::mesh::BucketVector& buckets) const
+{
+  unsigned numEntities = 0;
+  for (const auto* ib : buckets) {
+    unsigned subElemsPerElem =
+        (ib->topology().rank() == metaData.side_rank()) ?
+            std::pow(elemDescription_.polyOrder, dimension_ - 1) :
+            std::pow(elemDescription_.polyOrder, dimension_);
+
+    numEntities += ib->size()*subElemsPerElem;
+  }
+  return (numEntities);
+}
+//--------------------------------------------------------------------------
+size_t
+PromoteElement::count_entities(const stk::mesh::BucketVector& buckets) const
+{
+  unsigned numEntities = 0;
+  for (const auto* ib : buckets) {
+    numEntities += ib->size();
+  }
+  return numEntities;
+}
+//==========================================================================
+// Class Definition
+//==========================================================================
+// ChildNodeRequest - Provides some utilities to help promote elements
+//==========================================================================
+PromoteElement::ChildNodeRequest::ChildNodeRequest(
+  std::vector<stk::mesh::EntityId>  in_parentIds)
+: parentIds_(std::move(in_parentIds))
+{
+  ThrowAssert(std::is_sorted(parentIds_.begin(), parentIds_.end()));
+}
+//--------------------------------------------------------------------------
+void
+PromoteElement::ChildNodeRequest::set_node_entity_for_request(
+  stk::mesh::BulkData& mesh,
+  const stk::mesh::PartVector& base_parts) const
+{
+  auto parentParts = determine_parent_parts(mesh, base_parts);
+  ThrowRequire(!parentParts.empty());
+
+  stk::mesh::PartVector childParts(parentParts.size());
+  for (unsigned j = 0; j < parentParts.size(); ++j) {
+    const stk::mesh::Part& parentPart = *(parentParts[j]);
+    auto* part = promoted_part(parentPart);;
+    ThrowRequire(part != nullptr);
+
+    childParts[j] = part;
+  }
+
+  for (unsigned j = 0; j < children_.size(); ++j) {
+    auto& idProcPairs = idProcPairsFromAllProcs_[j];
+    std::sort(idProcPairs.begin(), idProcPairs.end());
+
+    children_[j] = mesh.declare_entity(
+      stk::topology::NODE_RANK, get_id_for_child(j), childParts
+    );
+
+    for (auto& idProcPair : idProcPairs) {
+      if (idProcPair.first != mesh.parallel_rank()) {
+        mesh.add_node_sharing(children_[j], idProcPair.first);
+      }
+    }
+  }
+}
+//--------------------------------------------------------------------------
+stk::mesh::PartVector
+PromoteElement::ChildNodeRequest::determine_parent_parts(
+  const stk::mesh::BulkData& mesh,
+  stk::mesh::PartVector base_parts) const
+{
+  std::sort(base_parts.begin(), base_parts.end());
+
+  for (unsigned i = 0; i < parentIds_.size(); ++i) {
+    auto parentNode = mesh.get_entity(stk::topology::NODE_RANK, parentIds_[i]);
+    stk::mesh::PartVector otherParts = mesh.bucket(parentNode).supersets();
+    std::sort(otherParts.begin(), otherParts.end());
+
+    stk::mesh::PartVector temp;
+    std::set_intersection(
+      base_parts.begin(), base_parts.end(),
+      otherParts.begin(), otherParts.end(),
+      std::back_inserter(temp)
+    );
+    base_parts = std::move(temp);
+  }
+  return base_parts;
+}
+//--------------------------------------------------------------------------
+void
+PromoteElement::ChildNodeRequest::determine_sharing_procs(
+  const stk::mesh::BulkData& mesh) const
+{
+  ThrowAssert(!parentIds_.empty());
+
+  mesh.comm_shared_procs(
+    { stk::topology::NODE_RANK, parentIds_[0] }, sharingProcs_
+  );
+  ThrowAssert(std::is_sorted(sharingProcs_.begin(), sharingProcs_.end()));
+
+  std::vector<int> parentSharingProcs;
+  for (unsigned i = 1; i < parentIds_.size(); ++i) {
+    mesh.comm_shared_procs(
+      { stk::topology::NODE_RANK, parentIds_[i] }, parentSharingProcs
+    );
+    ThrowAssert(std::is_sorted(parentSharingProcs.begin(), parentSharingProcs.end()));
+
+    std::vector<int> temp;
+    std::set_intersection(
+      sharingProcs_.begin(), sharingProcs_.end(),
+      parentSharingProcs.begin(), parentSharingProcs.end(),
+      std::back_inserter(temp)
+    );
+    sharingProcs_ = std::move(temp);
+  }
+}
+//--------------------------------------------------------------------------
+void
+PromoteElement::ChildNodeRequest::add_proc_id_pair(
+  int proc_id,
+  stk::mesh::EntityId id,
+  int childNumber) const
+{
+   idProcPairsFromAllProcs_[childNumber].emplace_back(proc_id, id);
+}
+//--------------------------------------------------------------------------
+void
+PromoteElement::ChildNodeRequest::add_shared_elem(
+  const stk::mesh::Entity& elem) const
+{
+  sharedElems_.push_back(elem);
+}
+//--------------------------------------------------------------------------
+stk::mesh::EntityId
+PromoteElement::ChildNodeRequest::get_id_for_child(int childNumber) const
+{
+  ThrowAssert(std::is_sorted(
+    idProcPairsFromAllProcs_[childNumber].begin(),
+    idProcPairsFromAllProcs_[childNumber].end()
+  ));
+  return idProcPairsFromAllProcs_[childNumber][0].second;
+}
+//--------------------------------------------------------------------------
+stk::mesh::EntityId
+PromoteElement::ChildNodeRequest::suggested_node_id(int childNumber) const
+{
+  return idProcPairsFromAllProcs_[childNumber][0].second;
+}
+//--------------------------------------------------------------------------
+std::vector<size_t>
+PromoteElement::ChildNodeRequest::determine_child_node_ordinal(
+  const stk::mesh::BulkData& mesh,
+  const ElementDescription& elemDesc,
+  unsigned elemNumber) const
+{
+  const auto& elem = sharedElems_[elemNumber];
+  stk::mesh::Entity const* node_rels = mesh.begin_nodes(elem);
+  const size_t numNodes = mesh.num_nodes(elem);
+  unsigned numParents = parentIds_.size();
+  std::vector<size_t> unsortedParentOrdinals(numParents);
+
+  // nodes are compared against a single set of parent ordinals
+  // for edges, the sorted parent ordinals still form a chain and can be used
+  // making the ordinals parallel consistent by construction
+
+  // For faces/volumes, I use the fact that the ordinals are not randomly ordered
+  // so I can't just use the sorted parentIds atm and have to enforce parallel consistency
+  // by sending over the reference parentIds
+  const auto& referenceIds = (numParents > 2) ? unsortedParentIds_ : parentIds_;
+
+  for (unsigned i = 0; i < numParents; ++i) {
+    for (unsigned j = 0; j < numNodes; ++j) {
+      if (mesh.identifier(node_rels[j]) == referenceIds[i]) {
+        unsortedParentOrdinals[i] = j;
+      }
+    }
+  }
+
+  std::vector<size_t> reorderedOrdinals;
+  for (const auto& relation : elemDesc.addedConnectivities) {
+    if (relation.second.size() == numParents) {
+      bool isPermutation = std::is_permutation(
+        relation.second.begin(),
+        relation.second.end(),
+        unsortedParentOrdinals.begin()
+      );
+
+      if (isPermutation) {
+        childOrdinalsForElem_[elemNumber] = relation.first;
+        break;
+      }
+    }
+  }
+  return unsortedParentOrdinals;
+}
+
+
+} // namespace nalu
+}  // namespace sierra

--- a/src/element_promotion/PromotedElementIO.C
+++ b/src/element_promotion/PromotedElementIO.C
@@ -1,0 +1,490 @@
+#include <element_promotion/PromotedElementIO.h>
+
+#include <element_promotion/PromoteElement.h>
+#include <element_promotion/ElementDescription.h>
+#include <nalu_make_unique.h>
+
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Bucket.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/BulkDataInlinedMethods.hpp>
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/FieldBase.hpp>
+#include <stk_mesh/base/FieldRestriction.hpp>
+#include <stk_mesh/base/Part.hpp>
+#include <stk_mesh/base/Selector.hpp>
+#include <stk_topology/topology.hpp>
+#include <stk_topology/topology.tcc>
+#include <stk_util/environment/ReportHandler.hpp>
+
+#include <Ioss_DBUsage.h>
+#include <Ioss_DatabaseIO.h>
+#include <Ioss_ElementBlock.h>
+#include <Ioss_Field.h>
+#include <Ioss_IOFactory.h>
+#include <Ioss_NodeBlock.h>
+#include <Ioss_Property.h>
+#include <Ioss_PropertyManager.h>
+#include <Ioss_SideBlock.h>
+#include <Ioss_SideSet.h>
+#include <Ioss_State.h>
+
+#include <algorithm>
+#include <iostream>
+#include <stdexcept>
+#include <utility>
+
+namespace sierra{
+namespace nalu{
+
+PromotedElementIO::PromotedElementIO(
+  const PromoteElement& promoteElement,
+  const stk::mesh::MetaData& metaData,
+  const stk::mesh::BulkData& bulkData,
+  const VectorFieldType& coordinates,
+  const std::string& fileName
+) : promoteElement_(promoteElement),
+    metaData_(metaData),
+    bulkData_(bulkData),
+    coordinates_(coordinates),
+    fileName_(fileName),
+    elem_(promoteElement.element_description()),
+    nDim_(metaData.spatial_dimension())
+{
+  databaseIO =
+      Ioss::IOFactory::create(
+        "exodus",
+        fileName_,
+        Ioss::WRITE_RESULTS,
+        bulkData_.parallel(),
+        Ioss::PropertyManager{}
+      );
+  ThrowRequire(databaseIO != nullptr && databaseIO->ok(true));
+
+  output_ = make_unique<Ioss::Region>(databaseIO, "HighOrderOutput"); //sink for databaseIO
+
+  const auto baseParts = promoteElement_.base_part_vector();
+//  ThrowRequireMsg(check_topology(baseParts),
+//    "Invalid topology for SubElement output: Only quads/Hexs are supported.");
+
+  const auto promotedParts = promoteElement_.promoted_part_vector();
+
+  const stk::mesh::BucketVector& elem_buckets = bulkData_.get_buckets(
+    stk::topology::ELEM_RANK, stk::mesh::selectUnion(baseParts));
+
+  size_t numSubElems = promoteElement_.num_sub_elements(metaData_,elem_buckets);
+  std::vector<stk::mesh::EntityId> subElemIds(numSubElems);
+
+  // generate new global ids.  Don't actually need to be unique for base element ids
+  bulkData_.generate_new_ids(
+    stk::topology::ELEM_RANK,
+    numSubElems,
+    subElemIds
+  );
+
+  output_->begin_mode(Ioss::STATE_DEFINE_MODEL);
+  write_node_block_definitions(baseParts, promotedParts);
+  write_elem_block_definitions(baseParts);
+  write_sideset_definitions(baseParts);
+  output_->end_mode(Ioss::STATE_DEFINE_MODEL);
+
+  output_->begin_mode(Ioss::STATE_MODEL);
+  write_coordinate_list(baseParts,promotedParts);
+  write_element_connectivity(baseParts,subElemIds);
+  write_sideset_connectivity(baseParts);
+  output_->end_mode(Ioss::STATE_MODEL);
+}
+//--------------------------------------------------------------------------
+void
+PromotedElementIO::write_database_data(double currentTime)
+{
+    output_->begin_mode(Ioss::STATE_TRANSIENT);
+    int current_output_step = output_->add_state(currentTime);
+    output_->begin_state(current_output_step);
+
+    stk::mesh::BucketVector const& nodeBuckets = bulkData_.get_buckets(
+      stk::topology::NODE_RANK, metaData_.universal_part());
+    size_t numNodes = promoteElement_.count_entities(nodeBuckets);
+
+    for (const auto* fieldPtr : fields_) {
+      const stk::mesh::FieldBase& field = *fieldPtr;
+      if (field.type_is<int>()) {
+        put_data_on_node_block<int>(*nodeBlock_, field, nodeBuckets, numNodes);
+      }
+      else if (field.type_is<double>()) {
+        put_data_on_node_block<double>(*nodeBlock_, field, nodeBuckets, numNodes);
+      }
+      else {
+        throw std::runtime_error("Unknown type");
+      }
+    }
+
+    output_->end_state(current_output_step);
+    output_->end_mode(Ioss::STATE_TRANSIENT);
+}
+//--------------------------------------------------------------------------
+int
+PromotedElementIO::maximum_field_length(const stk::mesh::FieldBase& field) const {
+  const stk::mesh::FieldRestrictionVector& restrictions = field.restrictions();
+  const unsigned restrictionLength = restrictions.size();
+  int maxFieldLength = 0;
+  for (unsigned k = 0; k < restrictionLength; ++k)  {
+    const stk::mesh::FieldRestriction&  restriction = restrictions[k];
+    maxFieldLength = std::max(maxFieldLength, restriction.num_scalars_per_entity());
+  }
+  return maxFieldLength;
+
+  //FIXME(rcknaus) does there actually need to be a parallel reduction for this?
+}
+//--------------------------------------------------------------------------
+template<typename T> void
+PromotedElementIO::put_data_on_node_block(
+  Ioss::NodeBlock& nodeBlock,
+  const stk::mesh::FieldBase& field,
+  const stk::mesh::BucketVector& buckets,
+  size_t numNodes) const
+{
+  int fieldLength = maximum_field_length(field);
+  std::vector<T> flat_array(numNodes*fieldLength);
+
+  size_t index = 0;
+  for (const auto* bucketPtr : buckets) {
+    const auto* field_data = static_cast<T*>(
+      stk::mesh::field_data(field, *bucketPtr));
+    const size_t length = bucketPtr->size();
+    size_t field_index = 0;
+    for (size_t k = 0; k < length; ++k) {
+      for (int j = 0; j < fieldLength; ++j) {
+        flat_array[index] = field_data[field_index];
+        ++index; ++field_index;
+      }
+    }
+  }
+  nodeBlock.put_field_data(field.name(),
+   flat_array.data(), flat_array.size() * sizeof(T));
+}
+//--------------------------------------------------------------------------
+void
+PromotedElementIO::write_elem_block_definitions(
+  const stk::mesh::PartVector& baseParts)
+{
+  for(const auto* ip : baseParts) {
+    if (ip->topology().rank() == stk::topology::ELEM_RANK) {
+      const auto& selector     = *ip & metaData_.locally_owned_part();
+      const auto& elemBuckets  = bulkData_.get_buckets(
+        stk::topology::ELEM_RANK, selector);
+      const size_t numSubElems = promoteElement_.num_sub_elements(
+        metaData_,elemBuckets);
+
+      auto block = make_unique<Ioss::ElementBlock>(
+        databaseIO,
+        ip->name(),
+        ip->topology().name(),
+        numSubElems
+      );
+      ThrowRequireMsg(block != nullptr, "Element block creation failed");
+
+      auto result = elementBlockPointers_.insert({ip,block.get()});
+      ThrowRequireMsg(result.second, "Attempted to add redundant part");
+
+      output_->add(block.release());
+    }
+  }
+}
+//--------------------------------------------------------------------------
+void
+PromotedElementIO::write_node_block_definitions(
+  const stk::mesh::PartVector&  /*baseParts*/,
+  const stk::mesh::PartVector&  /*promotedParts*/)
+{
+  auto& all_nodes = metaData_.universal_part();
+
+  const auto& nodeBuckets = bulkData_.get_buckets(
+    stk::topology::NODE_RANK, all_nodes);
+  auto nodeCount = promoteElement_.count_entities(nodeBuckets);
+  auto nodeBlock = make_unique<Ioss::NodeBlock>(
+    databaseIO, "nodeblock", nodeCount, nDim_);
+  ThrowRequireMsg(nodeBlock != nullptr, "Node block creation failed");
+  nodeBlock_ = nodeBlock.get();
+  output_->add(nodeBlock.release());
+}
+//--------------------------------------------------------------------------
+void
+PromotedElementIO::write_sideset_definitions(
+  const stk::mesh::PartVector& baseParts)
+{
+  for(const auto* ip : baseParts) {
+    const auto& part = *ip;
+
+    stk::mesh::PartVector subsets = part.subsets();
+    if (subsets.empty()) {
+      continue;
+    }
+
+    auto sideset = make_unique<Ioss::SideSet>(databaseIO, part.name());
+    ThrowRequireMsg(sideset != nullptr, "Sideset creation failed");
+
+    for (const auto* subpartPtr : subsets) {
+      const auto& subpart = *subpartPtr;
+
+      const auto subpartTopology = subpart.topology();
+      if (subpartTopology.rank() != metaData_.side_rank()) {
+        continue;
+      }
+
+      auto selector = metaData_.locally_owned_part() & subpart;
+      const auto& sideBuckets = bulkData_.get_buckets(
+        metaData_.side_rank(),
+        selector
+      );
+      const size_t numSubElemsInPart = promoteElement_.num_sub_elements(
+        metaData_,
+        sideBuckets
+      );
+
+      auto block = make_unique<Ioss::SideBlock>(
+        databaseIO,
+        subpart.name(),
+        subpartTopology.name(),
+        part.topology().name(),
+        numSubElemsInPart
+      );
+      ThrowRequireMsg(block != nullptr, "Sideblock creation failed");
+
+      auto result = sideBlockPointers_.insert({ subpartPtr, block.get() });
+      ThrowRequireMsg(result.second, "Attempted to add redundant subpart");
+
+      sideset->add(block.release());
+    }
+    output_->add(sideset.release());
+  }
+}
+//--------------------------------------------------------------------------
+bool
+PromotedElementIO::check_topology(const stk::mesh::PartVector& baseParts) const
+{
+  const auto validElemTopology = (nDim_ == 2) ?
+      stk::topology::QUAD_4_2D : stk::topology::HEX_8;
+
+  const auto validSideTopology = (nDim_ == 2) ?
+      stk::topology::LINE_2 : stk::topology::QUAD_4;
+
+  bool okTopo =  false;
+  for(const auto* ip : baseParts) {
+    auto validTopology = (ip->topology().rank() == metaData_.side_rank()) ?
+        validSideTopology : validElemTopology;
+
+    if (ip->topology().value() == validTopology) {
+      okTopo = true;
+    }
+    else {
+      std::cout << ip->topology().value() << std::endl;
+      return false;
+    }
+
+    for (const auto* subip : ip->subsets()) {
+      auto validTopology = (subip->topology().rank() == metaData_.side_rank()) ?
+          validSideTopology : validElemTopology;
+
+      if (subip->topology().value() == validTopology) {
+        okTopo = true;
+      }
+      else {
+        return false;
+      }
+    }
+  }
+  return okTopo;
+}
+//--------------------------------------------------------------------------
+void
+PromotedElementIO::write_coordinate_list(
+  const stk::mesh::PartVector&  /*baseParts*/,
+  const stk::mesh::PartVector&  /*promotedParts*/)
+{
+  auto& all_nodes = metaData_.universal_part();
+
+  const auto& nodeBuckets =
+      bulkData_.get_buckets(stk::topology::NODE_RANK, all_nodes);
+
+  auto nodeCount = promoteElement_.count_entities(nodeBuckets);
+
+  std::vector<int> node_ids;
+  std::vector<double> coordvec;
+  node_ids.reserve(nodeCount);
+  coordvec.reserve(nodeCount*nDim_);
+
+  for (const auto* ib : nodeBuckets) {
+    const stk::mesh::Bucket& b = *ib;
+    const stk::mesh::Bucket::size_type length = b.size();
+    for (stk::mesh::Bucket::size_type k = 0; k < length; ++k) {
+      const auto& node = b[k];
+      node_ids.push_back(bulkData_.identifier(node));
+      const double* coords =
+          static_cast<double*>(stk::mesh::field_data(coordinates_,node));
+
+      for (unsigned j = 0; j < nDim_; ++j) {
+        coordvec.push_back(coords[j]);
+      }
+    }
+  }
+  nodeBlock_->put_field_data("ids", node_ids);
+  nodeBlock_->put_field_data("mesh_model_coordinates",
+    coordvec.data(),
+    nodeCount * nDim_ * sizeof(double)
+  );
+
+}
+//--------------------------------------------------------------------------
+void
+PromotedElementIO::write_element_connectivity(
+  const stk::mesh::PartVector& baseParts,
+  const std::vector<stk::mesh::EntityId>& entityIds)
+{
+  auto subConnectivity = elem_.subElementConnectivity;
+
+  for(const auto* ip : baseParts) {
+    const stk::mesh::Part& part = *ip;
+    if(part.topology().rank() !=stk::topology::ELEM_RANK) {
+      continue;
+    }
+
+    const auto& selector = metaData_.locally_owned_part() & part;
+    const auto& elemBuckets =
+        bulkData_.get_buckets(stk::topology::ELEM_RANK, selector);
+
+    const size_t numberSubElementsInBlock =
+        promoteElement_.num_sub_elements(metaData_,elemBuckets);
+    const unsigned nodesPerLinearElem = part.topology().num_nodes();
+
+    std::vector<int> connectivity(nodesPerLinearElem*numberSubElementsInBlock);
+    std::vector<int> globalSubElementIds(numberSubElementsInBlock);
+
+    int connIndex = 0;
+    unsigned subElementCounter = 0;
+    for (const auto* ib: elemBuckets) {
+      const stk::mesh::Bucket& b = *ib;
+      const auto length = b.size();
+      for (size_t k = 0; k < length; ++k) {
+        const auto* node_rels = promoteElement_.begin_nodes_all(b[k]);
+        const auto& subElems = subConnectivity;
+        const auto numberSubElements = subElems.size();
+
+        for (unsigned subElementIndex = 0; subElementIndex < numberSubElements; ++subElementIndex) {
+          globalSubElementIds.at(subElementCounter) = entityIds[subElementCounter];
+
+          const auto& localIndices = subElems.at(subElementIndex);
+          for (unsigned j = 0; j < nodesPerLinearElem; ++j) {
+            connectivity.at(connIndex) = bulkData_.identifier(node_rels[localIndices[j]]);
+            ++connIndex;
+          }
+          ++subElementCounter;
+        }
+      }
+    }
+
+    elementBlockPointers_.at(ip)->put_field_data(
+      "ids",  globalSubElementIds
+    );
+
+    elementBlockPointers_.at(ip)->put_field_data(
+      "connectivity", connectivity
+    );
+  }
+}
+
+void
+PromotedElementIO::write_sideset_connectivity(
+  const stk::mesh::PartVector&  /*baseParts*/)
+{
+  //FIXME(rcknaus): implement
+}
+//--------------------------------------------------------------------------
+void
+PromotedElementIO::add_fields(const std::vector<stk::mesh::FieldBase*>& fields)
+{
+  output_->begin_mode(Ioss::STATE_DEFINE_TRANSIENT);
+  for (const auto* fieldPtr : fields) {
+    const auto& field = *fieldPtr;
+
+    auto result = fields_.insert(fieldPtr);
+    bool wasFieldAdded = result.second;
+
+    if (wasFieldAdded) {
+      int nb_size = nodeBlock_->get_property("entity_count").get_int();
+
+      if (field.type_is<int>()) {
+        nodeBlock_->field_add(
+          Ioss::Field(
+            field.name(),
+            Ioss::Field::INTEGER,
+            storage_name(field),
+            Ioss::Field::TRANSIENT,
+            nb_size
+          )
+        );
+      }
+      else if (field.type_is<double>()) {
+        nodeBlock_->field_add(
+          Ioss::Field(
+            field.name(),
+            Ioss::Field::DOUBLE,
+            storage_name(field),
+            Ioss::Field::TRANSIENT,
+            nb_size
+          )
+        );
+      }
+      else {
+        throw std::runtime_error("Only int and double fields supported");
+      }
+    }
+  }
+  output_->end_mode(Ioss::STATE_DEFINE_TRANSIENT);
+}
+//--------------------------------------------------------------------------
+std::string
+PromotedElementIO::storage_name(const stk::mesh::FieldBase& field) const
+{
+  std::string storageType;
+  switch (maximum_field_length(field)) {
+    case 1:
+    {
+      storageType = "scalar";
+      break;
+    }
+    case 2:
+    {
+      storageType = "vector_2d";
+      break;
+    }
+    case 3:
+    {
+      storageType = "vector_3d";
+      break;
+    }
+    case 4:
+    {
+      storageType = "full_tensor_22";
+      break;
+    }
+    case 6:
+    {
+      storageType = "sym_tensor_33";
+      break;
+    }
+    case 9:
+    {
+      storageType = "full_tensor_36";
+      break;
+    }
+    default: {
+      storageType = "GeneralField";
+      break;
+    }
+  }
+  return storageType;
+}
+
+}  // namespace nalu
+}  // namespace sierra

--- a/src/element_promotion/QuadratureRule.C
+++ b/src/element_promotion/QuadratureRule.C
@@ -1,0 +1,201 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+#include <element_promotion/QuadratureRule.h>
+
+#include <Teuchos_RCP.hpp>
+#include <Teuchos_LAPACK.hpp>
+#include <Teuchos_SerialDenseMatrix.hpp>
+#include <Teuchos_SerialDenseSolver.hpp>
+#include <Teuchos_SerialDenseVector.hpp>
+
+#include <cmath>
+#include <vector>
+
+namespace sierra{
+namespace nalu{
+
+std::pair<Teuchos::SerialDenseVector<int, double>, Teuchos::SerialDenseVector<int, double>>
+jacobi_recursion_coefficients(
+    const double alpha,
+    const double beta,
+    const int order)
+{
+  int N = order;
+  Teuchos::SerialDenseVector<int, double> a(N);
+  Teuchos::SerialDenseVector<int, double> b(N);
+
+  double nu = (beta - alpha) / (alpha + beta + 2.0);
+  double mu = std::pow(2.0, alpha + beta + 1.0) * std::tgamma(alpha + 1.0)
+  * std::tgamma(beta + 1.0) / std::tgamma(alpha + beta + 2.0);
+  double nab;
+  double sqdif = beta * beta - alpha * alpha;
+
+  a[0] = nu;
+  b[0] = mu;
+
+  if (N > 1) {
+    for (int n = 1; n < N; ++n) {
+      nab = 2 * n + alpha + beta;
+      a[n] = sqdif / (nab * (nab + 2));
+    }
+
+    b[1] = 4.0 * (alpha + 1.0) * (beta + 1.0)
+                    / (std::pow(alpha + beta + 2.0, 2) * (alpha + beta + 3.0));
+
+    if (N > 2) {
+      for (int n = 2; n < N; ++n) {
+        nab = 2 * n + alpha + beta;
+        b[n] = 4.0 * (n + alpha) * (n + beta) * n * (n + alpha + beta)
+                        / (nab * nab * (nab + 1.0) * (nab - 1.0));
+      }
+    }
+  }
+  return std::make_pair(a, b);
+}
+//--------------------------------------------------------------------
+std::pair<std::vector<double>, std::vector<double>>
+gauss_legendre_rule(int order)
+{
+  int INFO;
+  const int N = order;
+  const char COMPZ = 'I';
+
+  Teuchos::SerialDenseVector<int, double> D(N);
+  Teuchos::SerialDenseVector<int, double> b(N);
+  Teuchos::SerialDenseVector<int, double> E(N);
+  Teuchos::SerialDenseVector<int, double> work(4 * N);
+  Teuchos::SerialDenseMatrix<int, double> Z(N, N);
+
+  std::tie(D, b) = jacobi_recursion_coefficients(0.0, 0.0, order);
+
+  for (int i = 0; i < N - 1; ++i) {
+    E[i] = std::sqrt(b[i + 1]);
+  }
+
+  Teuchos::LAPACK<int, double>().STEQR(
+    COMPZ, N, D.values(), E.values(),
+    Z.values(), N, work.values(), &INFO
+  );
+
+  std::vector<double> x(N);
+  std::vector<double> w(N);
+  for (int i = 0; i < N; ++i) {
+    x[i] = D(i);
+    w[i] = b[0] * Z(0, i) * Z(0, i);
+  }
+  return std::make_pair(x, w);
+}
+//--------------------------------------------------------------------
+std::pair<Teuchos::SerialDenseVector<int, double>, Teuchos::SerialDenseVector<int, double>>
+coefficients_for_lobatto(
+  int order,
+  double xl1,
+  double xl2)
+{
+  const int N = order - 1;
+
+  Teuchos::SerialDenseVector<int, double> en(N);
+  Teuchos::SerialDenseVector<int, double> g(N);
+  Teuchos::SerialDenseMatrix<int, double> M(N, N);
+  Teuchos::SerialDenseSolver<int, double> solver;
+  Teuchos::SerialDenseVector<int, double> a;
+  Teuchos::SerialDenseVector<int, double> b;
+  std::tie(a, b) = jacobi_recursion_coefficients(0.0, 0.0, N);
+
+  // Nth canonical vector
+  en[N - 1] = 1;
+
+  for (int i = 0; i < N; ++i) {
+    M(i, i) = a[i] - xl1;
+  }
+
+  for (int i = 0; i < N - 1; ++i) {
+    double offdiag = std::sqrt(b[i + 1]);
+    M(i + 1, i) = offdiag;
+    M(i, i + 1) = offdiag;
+  }
+
+  solver.setMatrix(Teuchos::rcp(&M, false));
+  solver.setVectors(Teuchos::rcp(&g, false), Teuchos::rcp(&en, false));
+  solver.solve();
+  double g1 = g[N - 1];
+
+  M.putScalar(0.0);
+  en.putScalar(0.0);
+  g.putScalar(0.0);
+  en[N - 1] = 1;
+  for (int i = 0; i < N; ++i) {
+    M(i, i) = a[i] - xl2;
+  }
+
+  for (int i = 0; i < N - 1; ++i) {
+    double offdiag = std::sqrt(b[i + 1]);
+    M(i + 1, i) = offdiag;
+    M(i, i + 1) = offdiag;
+  }
+
+  solver.setMatrix(Teuchos::rcp(&M, false));
+  solver.setVectors(Teuchos::rcp(&g, false), Teuchos::rcp(&en, false));
+  solver.solve();
+  double g2 = g[N - 1];
+
+  Teuchos::SerialDenseVector<int, double> amod(N + 1);
+  Teuchos::SerialDenseVector<int, double> bmod(N + 1);
+
+  for (int i = 0; i < N; ++i) {
+    amod[i] = a[i];
+    bmod[i] = b[i];
+  }
+  amod[N] = (g1 * xl2 - g2 * xl1) / (g1 - g2);
+  bmod[N] = (xl2 - xl1) / (g1 - g2);
+
+  return std::make_pair(amod, bmod);
+}
+//--------------------------------------------------------------------
+std::pair<std::vector<double>, std::vector<double>>
+gauss_lobatto_legendre_rule(
+  int order,
+  double xleft,
+  double xright)
+{
+  int INFO;
+  const int N = order;
+  const char COMPZ = 'I';
+
+  Teuchos::SerialDenseVector<int, double> D(N);
+  Teuchos::SerialDenseVector<int, double> b(N);
+  Teuchos::SerialDenseVector<int, double> E(N);
+  Teuchos::SerialDenseVector<int, double> work(4 * N);
+  Teuchos::SerialDenseMatrix<int, double> Z(N, N);
+
+  std::tie(D, b) = coefficients_for_lobatto(order, xleft, xright);
+
+  for (int i = 0; i < N - 1; ++i) {
+    E[i] = std::sqrt(b[i + 1]);
+  }
+
+  Teuchos::LAPACK<int, double>().STEQR(
+    COMPZ, N, D.values(), E.values(),
+    Z.values(), N, work.values(), &INFO
+  );
+
+  std::vector<double> x(N);
+  std::vector<double> w(N);
+  for (int i = 0; i < N; ++i) {
+    x[i] = D(i);
+    w[i] = b[0] * Z(0, i) * Z(0, i);
+  }
+
+  //remove machine eps from end points
+  x[0] = xleft;
+  x[N - 1] = xright;
+
+  return std::make_pair(x, w);
+}
+
+}  // namespace nalu
+}  // namespace sierra

--- a/src/element_promotion/TensorProductQuadratureRule.C
+++ b/src/element_promotion/TensorProductQuadratureRule.C
@@ -1,0 +1,99 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+#include <element_promotion/TensorProductQuadratureRule.h>
+#include <element_promotion/QuadratureRule.h>
+
+#include <cmath>
+#include <stdexcept>
+
+namespace sierra{
+namespace nalu{
+
+TensorProductQuadratureRule::TensorProductQuadratureRule(
+  std::string  /*type*/,
+  int numQuad,
+  std::vector<double>& scsLocs)
+{
+  scsEndLoc_.resize(scsLocs.size()+2);
+  scsEndLoc_[0] = -1.0;
+
+  for (unsigned j = 0; j < scsLocs.size();++j) {
+    scsEndLoc_[j+1] = scsLocs[j];
+  }
+  scsEndLoc_[scsLocs.size()+1] = +1.0;
+
+  std::tie(abscissae_, weights_) = gauss_legendre_rule(numQuad);
+  double isoparametricFactor = 0.5;
+  for (auto& weight : weights_) {
+    weight *= isoparametricFactor;
+  }
+}
+//--------------------------------------------------------------------------
+double
+TensorProductQuadratureRule::isoparametric_mapping(
+  const double b,
+  const double a,
+  const double xi) const
+{
+  return (0.5*(xi*(b-a) + (a+b)));
+}
+//--------------------------------------------------------------------------
+double
+TensorProductQuadratureRule::gauss_point_location(
+  int nodeOrdinal,
+  int gaussPointOrdinal) const
+{
+
+  double location1D =
+      isoparametric_mapping( scsEndLoc_[nodeOrdinal+1],
+                             scsEndLoc_[nodeOrdinal],
+                             abscissae_[gaussPointOrdinal] );
+   return location1D;
+}
+//--------------------------------------------------------------------------
+double
+TensorProductQuadratureRule::tensor_product_weight(
+  int s1Node, int s2Node, int s3Node,
+  int s1Ip, int s2Ip, int s3Ip) const
+{
+  const double Ls1 = scsEndLoc_[s1Node+1]-scsEndLoc_[s1Node];
+  const double Ls2 = scsEndLoc_[s2Node+1]-scsEndLoc_[s2Node];
+  const double Ls3 = scsEndLoc_[s3Node+1]-scsEndLoc_[s3Node];
+  const double isoparametricArea = Ls1 * Ls2 * Ls3;
+
+  const double weight =
+      isoparametricArea * weights_[s1Ip] * weights_[s2Ip] * weights_[s3Ip];
+
+  return weight;
+
+}
+//--------------------------------------------------------------------------
+double
+TensorProductQuadratureRule::tensor_product_weight(
+  int s1Node, int s2Node,
+  int s1Ip, int s2Ip) const
+{
+  //surface integration
+  const double Ls1 = scsEndLoc_[s1Node+1]-scsEndLoc_[s1Node];
+  const double Ls2 = scsEndLoc_[s2Node+1]-scsEndLoc_[s2Node];
+  const double isoparametricArea = Ls1 * Ls2;
+  const double weight = isoparametricArea * weights_[s1Ip] * weights_[s2Ip];
+
+  return weight;
+}
+//--------------------------------------------------------------------------
+double
+TensorProductQuadratureRule::tensor_product_weight(int s1Node, int s1Ip) const
+{
+  const double isoparametricLength = scsEndLoc_[s1Node+1]-scsEndLoc_[s1Node];
+  const double weight = isoparametricLength * weights_[s1Ip];
+
+  return weight;
+}
+
+}  // namespace nalu
+} // namespace sierra

--- a/src/master_element/MasterElement.C
+++ b/src/master_element/MasterElement.C
@@ -5505,7 +5505,7 @@ Quad92DSCS::set_boundary_info()
 
   faceOrdinal = 3; //left face
   oppFaceIndex = 0;
-  //NOTE: this faces is reversed
+  //NOTE: this face is reversed
   for (int k = nodes1D_-1; k >= 0; --k) {
     const int nearNode = face_node_number(nodes1D_-k-1,faceOrdinal);
     int oppNode = tensor_product_node_map(1,k);

--- a/src/mesh_motion/AssembleMeshDisplacementElemSolverAlgorithm.C
+++ b/src/mesh_motion/AssembleMeshDisplacementElemSolverAlgorithm.C
@@ -163,8 +163,8 @@ AssembleMeshDisplacementElemSolverAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );

--- a/src/mesh_motion/AssemblePressureForceBCSolverAlgorithm.C
+++ b/src/mesh_motion/AssemblePressureForceBCSolverAlgorithm.C
@@ -154,8 +154,8 @@ AssemblePressureForceBCSolverAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = bulk_data .begin_nodes(face);
-      int num_face_nodes = bulk_data.num_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
+      int num_face_nodes = realm_.num_nodes_all(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -178,13 +178,13 @@ AssemblePressureForceBCSolverAlgorithm::execute()
       // get element; its face ordinal number and populate face_node_ordinal_vec
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = bulk_data.begin_element_ordinals(face)[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinal_vec.begin());
+              realm_.side_node_ordinals_all(theElemTopo, face_ordinal, face_node_ordinal_vec);
 
       //==========================================
       // gather nodal data off of element; n/a
       //==========================================
-      stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
-      int num_nodes = bulk_data.num_nodes(element);
+      stk::mesh::Entity const * elem_node_rels = realm_.begin_nodes_all(element);
+      int num_nodes = realm_.num_nodes_all(element);
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerElement );
       for ( int ni = 0; ni < num_nodes; ++ni ) {

--- a/src/overset/OversetInfo.C
+++ b/src/overset/OversetInfo.C
@@ -43,5 +43,5 @@ OversetInfo::~OversetInfo()
   // nothing to delete
 }
 
-} // namespace NaluUnit
+} // namespace nalu
 } // namespace sierra

--- a/src/overset/OversetManager.C
+++ b/src/overset/OversetManager.C
@@ -288,8 +288,8 @@ OversetManager::define_overset_bounding_box()
       stk::mesh::Entity element = b[k];
 
       // extract elem_node_relations
-      stk::mesh::Entity const* elem_node_rels = bulkData_->begin_nodes(element);
-      const int num_nodes = bulkData_->num_nodes(element);
+      stk::mesh::Entity const* elem_node_rels = realm_.begin_nodes_all(element);
+      const int num_nodes = realm_.num_nodes_all(element);
 
       for ( int ni = 0; ni < num_nodes; ++ni ) {
         stk::mesh::Entity node = elem_node_rels[ni];
@@ -407,8 +407,8 @@ OversetManager::define_overset_bounding_boxes()
       }
         
       // extract elem_node_relations
-      stk::mesh::Entity const* elem_node_rels = bulkData_->begin_nodes(element);
-      const int num_nodes = bulkData_->num_nodes(element);
+      stk::mesh::Entity const* elem_node_rels = realm_.begin_nodes_all(element);
+      const int num_nodes = realm_.num_nodes_all(element);
         
       for ( int ni = 0; ni < num_nodes; ++ni ) {
         stk::mesh::Entity node = elem_node_rels[ni];
@@ -473,8 +473,8 @@ OversetManager::define_background_bounding_boxes()
       }
         
       // extract elem_node_relations
-      stk::mesh::Entity const* elem_node_rels = bulkData_->begin_nodes(element);
-      const int num_nodes = bulkData_->num_nodes(element);
+      stk::mesh::Entity const* elem_node_rels = realm_.begin_nodes_all(element);
+      const int num_nodes = realm_.num_nodes_all(element);
         
       for ( int ni = 0; ni < num_nodes; ++ni ) {
         stk::mesh::Entity node = elem_node_rels[ni];
@@ -945,5 +945,5 @@ OversetManager::complete_search(
   }  
 }
 
-} // namespace naluUnit
+} // namespace nalu
 } // namespace Sierra

--- a/src/pmr/AssembleRadTransWallSolverAlgorithm.C
+++ b/src/pmr/AssembleRadTransWallSolverAlgorithm.C
@@ -69,7 +69,6 @@ void
 AssembleRadTransWallSolverAlgorithm::execute()
 {
 
-  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -147,7 +146,7 @@ AssembleRadTransWallSolverAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(face);
       for ( int ni = 0; ni < nodesPerFace; ++ni ) {
         stk::mesh::Entity node = face_node_rels[ni];
         connected_nodes[ni] = node;

--- a/src/pmr/RadiativeTransportEquationSystem.C
+++ b/src/pmr/RadiativeTransportEquationSystem.C
@@ -1121,10 +1121,10 @@ RadiativeTransportEquationSystem::assemble_boundary_area()
       const double * areaVec = stk::mesh::field_data(*exposedAreaVec, b, k);
 
       // face node relations for nodal gather
-      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(b,k);
 
       // number of nodes (equals ips) and face data
-      int num_face_ip = b.num_nodes(k);
+      int num_face_ip = realm_.num_nodes_all(b,k);
 
       for ( int ip = 0; ip < num_face_ip; ++ip ) {
 
@@ -1257,8 +1257,8 @@ RadiativeTransportEquationSystem::assemble_irradiation()
       const double * areaVec = stk::mesh::field_data(*exposedAreaVec, b, k);
 
       // face node relations for nodal gather
-      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
-      int num_nodes = b.num_nodes(k);
+      stk::mesh::Entity const * face_node_rels = realm_.begin_nodes_all(b,k);
+      int num_nodes = realm_.num_nodes_all(b,k);
       for ( int ni = 0; ni < num_nodes; ++ni ) {
         // gather scalar
         p_intensity[ni] = *stk::mesh::field_data(*intensity_, face_node_rels[ni]);

--- a/src/user_functions/SteadyTaylorVortexContinuitySrcElemSuppAlg.C
+++ b/src/user_functions/SteadyTaylorVortexContinuitySrcElemSuppAlg.C
@@ -106,8 +106,8 @@ SteadyTaylorVortexContinuitySrcElemSuppAlg::elem_execute(
   const int numScvIp = meSCV->numIntPoints_;
   
   // gather
-  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
-  int num_nodes = bulkData_->num_nodes(element);
+  stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(element);
+  int num_nodes = realm_.num_nodes_all(element);
   
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );

--- a/src/user_functions/SteadyTaylorVortexMixFracSrcElemSuppAlg.C
+++ b/src/user_functions/SteadyTaylorVortexMixFracSrcElemSuppAlg.C
@@ -106,8 +106,8 @@ SteadyTaylorVortexMixFracSrcElemSuppAlg::elem_execute(
   const int numScvIp = meSCV->numIntPoints_;
   
   // gather
-  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
-  int num_nodes = bulkData_->num_nodes(element);
+  stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(element);
+  int num_nodes = realm_.num_nodes_all(element);
   
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );

--- a/src/user_functions/SteadyTaylorVortexMomentumSrcElemSuppAlg.C
+++ b/src/user_functions/SteadyTaylorVortexMomentumSrcElemSuppAlg.C
@@ -104,8 +104,8 @@ SteadyTaylorVortexMomentumSrcElemSuppAlg::elem_execute(
   const int numScvIp = meSCV->numIntPoints_;
   
   // gather
-  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
-  int num_nodes = bulkData_->num_nodes(element);
+  stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(element);
+  int num_nodes = realm_.num_nodes_all(element);
   
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );

--- a/src/user_functions/SteadyThermalContact3DAuxFunction.C
+++ b/src/user_functions/SteadyThermalContact3DAuxFunction.C
@@ -1,0 +1,55 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include <user_functions/SteadyThermalContact3DAuxFunction.h>
+#include <algorithm>
+
+// basic c++
+#include <cmath>
+#include <vector>
+#include <stdexcept>
+
+namespace sierra{
+namespace nalu{
+
+SteadyThermalContact3DAuxFunction::SteadyThermalContact3DAuxFunction() :
+  AuxFunction(0,1),
+  a_(1.0),
+  k_(1.0),
+  pi_(std::acos(-1.0))
+{
+  // nothing to do
+}
+
+
+void
+SteadyThermalContact3DAuxFunction::do_evaluate(
+  const double *coords,
+  const double t,
+  const unsigned spatialDimension,
+  const unsigned numPoints,
+  double * fieldPtr,
+  const unsigned fieldSize,
+  const unsigned /*beginPos*/,
+  const unsigned /*endPos*/) const
+{
+  for(unsigned p=0; p < numPoints; ++p) {
+
+    double x = coords[0];
+    double y = coords[1];
+    double z = coords[2];
+
+    fieldPtr[0] = k_/4.0*(cos(2.*a_*pi_*x) + cos(2.*a_*pi_*y) + cos(2.*a_*pi_*z));
+    
+    fieldPtr += fieldSize;
+    coords += spatialDimension;
+  }
+}
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/user_functions/SteadyThermalContact3DSrcElemSuppAlg.C
+++ b/src/user_functions/SteadyThermalContact3DSrcElemSuppAlg.C
@@ -1,0 +1,174 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include <user_functions/SteadyThermalContact3DSrcElemSuppAlg.h>
+#include <SupplementalAlgorithm.h>
+#include <FieldTypeDef.h>
+#include <Realm.h>
+#include <master_element/MasterElement.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// SteadyThermalContact3DSrcElemSuppAlg - base class for algorithm
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+SteadyThermalContact3DSrcElemSuppAlg::SteadyThermalContact3DSrcElemSuppAlg(
+  Realm &realm)
+  : SupplementalAlgorithm(realm),
+    bulkData_(&realm.bulk_data()),
+    coordinates_(NULL),
+    a_(1.0),
+    k_(1.0),
+    pi_(std::acos(-1.0)),
+    useShifted_(false),
+    nDim_(realm_.spatialDimension_),
+    evalAtIps_(true)
+{
+  // save off fields
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+ 
+  // scratch vecs
+  scvCoords_.resize(nDim_);
+}
+
+//--------------------------------------------------------------------------
+//-------- elem_resize -----------------------------------------------------
+//--------------------------------------------------------------------------
+void
+SteadyThermalContact3DSrcElemSuppAlg::elem_resize(
+  MasterElement */*meSCS*/,
+  MasterElement *meSCV)
+{
+  const int nodesPerElement = meSCV->nodesPerElement_;
+  const int numScvIp = meSCV->numIntPoints_;
+  ws_shape_function_.resize(numScvIp*nodesPerElement);
+  ws_coordinates_.resize(nDim_*nodesPerElement);
+  ws_scv_volume_.resize(numScvIp);
+  ws_nodalSrc_.resize(nodesPerElement);
+
+  // compute shape function
+  if ( useShifted_ )
+    meSCV->shifted_shape_fcn(&ws_shape_function_[0]);
+  else
+    meSCV->shape_fcn(&ws_shape_function_[0]);
+}
+
+//--------------------------------------------------------------------------
+//-------- setup -----------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+SteadyThermalContact3DSrcElemSuppAlg::setup()
+{
+  // nothing
+}
+
+//--------------------------------------------------------------------------
+//-------- elem_execute ----------------------------------------------------
+//--------------------------------------------------------------------------
+void
+SteadyThermalContact3DSrcElemSuppAlg::elem_execute(
+  double */*lhs*/,
+  double *rhs,
+  stk::mesh::Entity element,
+  MasterElement */*meSCS*/,
+  MasterElement *meSCV)
+{
+  // pointer to ME methods
+  const int *ipNodeMap = meSCV->ipNodeMap();
+  const int nodesPerElement = meSCV->nodesPerElement_;
+  const int numScvIp = meSCV->numIntPoints_;
+
+  // gather
+  stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(element);
+  int num_nodes = realm_.num_nodes_all(element);
+
+  // sanity check on num nodes
+  ThrowAssert( num_nodes == nodesPerElement );
+
+  for ( int ni = 0; ni < num_nodes; ++ni ) {
+    stk::mesh::Entity node = node_rels[ni];
+    // pointers to real data
+    const double * coords = stk::mesh::field_data(*coordinates_, node );
+    // gather vectors
+    const int niNdim = ni*nDim_;
+    for ( int j=0; j < nDim_; ++j ) {
+      ws_coordinates_[niNdim+j] = coords[j];
+    }
+  }
+
+  // compute geometry
+  double scv_error = 0.0;
+  meSCV->determinant(1, &ws_coordinates_[0], &ws_scv_volume_[0], &scv_error);
+
+  // choose a form...
+  if ( evalAtIps_ ) {
+    // interpolate to ips and evaluate source
+    for ( int ip = 0; ip < numScvIp; ++ip ) {
+      
+      // nearest node to ip
+      const int nearestNode = ipNodeMap[ip];
+      
+      // zero out
+      for ( int j =0; j < nDim_; ++j )
+        scvCoords_[j] = 0.0;
+      
+      const int offSet = ip*nodesPerElement;
+      for ( int ic = 0; ic < nodesPerElement; ++ic ) {
+        const double r = ws_shape_function_[offSet+ic];
+        for ( int j = 0; j < nDim_; ++j )
+          scvCoords_[j] += r*ws_coordinates_[ic*nDim_+j];
+      }
+      const double x = scvCoords_[0];
+      const double y = scvCoords_[1];
+      const double z = scvCoords_[2];
+      rhs[nearestNode] += k_/4.0*
+          (2.0*a_*pi_)*(2.0*a_*pi_)*(cos(2.0*a_*pi_*x) + cos(2.0*a_*pi_*y) + cos(2.0*a_*pi_*z))*ws_scv_volume_[ip];
+    }
+  }
+  else {
+    // evaluate source at nodal location
+    for ( int ni = 0; ni < nodesPerElement; ++ni ) {
+      const double x = ws_coordinates_[ni*nDim_+0];
+      const double y = ws_coordinates_[ni*nDim_+1];
+      const double z = ws_coordinates_[ni*nDim_+2];
+      ws_nodalSrc_[ni] = k_/4.0*(2.0*a_*pi_)*(2.0*a_*pi_)*(cos(2.0*a_*pi_*x) + cos(2.0*a_*pi_*y) + cos(2.0*a_*pi_*z));
+    }
+
+    // interpolate nodal source term to ips and assemble to nodes
+    for ( int ip = 0; ip < numScvIp; ++ip ) {
+      
+      // nearest node to ip
+      const int nearestNode = ipNodeMap[ip];
+      
+      double ipSource = 0.0;
+
+      const int offSet = ip*nodesPerElement;
+      for ( int ic = 0; ic < nodesPerElement; ++ic ) {
+        const double r = ws_shape_function_[offSet+ic];
+        ipSource += r*ws_nodalSrc_[ic];
+      }
+      rhs[nearestNode] += ipSource*ws_scv_volume_[ip];
+    } 
+  }
+}
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/user_functions/SteadyThermalContact3DSrcNodeSuppAlg.C
+++ b/src/user_functions/SteadyThermalContact3DSrcNodeSuppAlg.C
@@ -1,0 +1,76 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include <user_functions/SteadyThermalContact3DSrcNodeSuppAlg.h>
+#include <SupplementalAlgorithm.h>
+#include <FieldTypeDef.h>
+#include <Realm.h>
+#include <TimeIntegrator.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// SteadyThermalContact3DSrcNodeSuppAlg - base class for algorithm
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+SteadyThermalContact3DSrcNodeSuppAlg::SteadyThermalContact3DSrcNodeSuppAlg(
+  Realm &realm)
+  : SupplementalAlgorithm(realm),
+    coordinates_(NULL),
+    dualNodalVolume_(NULL),
+    a_(1.0),
+    k_(1.0),
+    pi_(std::acos(-1.0))
+{
+  // save off fields
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+}
+
+//--------------------------------------------------------------------------
+//-------- setup -----------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+SteadyThermalContact3DSrcNodeSuppAlg::setup()
+{
+  // nothing
+}
+
+//--------------------------------------------------------------------------
+//-------- node_execute ----------------------------------------------------
+//--------------------------------------------------------------------------
+void
+SteadyThermalContact3DSrcNodeSuppAlg::node_execute(
+  double *lhs,
+  double *rhs,
+  stk::mesh::Entity node)
+{
+  // deal with lumped mass matrix
+  const double *coords = stk::mesh::field_data(*coordinates_, node);
+  const double dualVolume = *stk::mesh::field_data(*dualNodalVolume_, node );
+  const double x = coords[0];
+  const double y = coords[1];
+  const double z = coords[2];
+  rhs[0] += k_/4.0*(2.0*a_*pi_)*(2.0*a_*pi_)*(cos(2.0*a_*pi_*x) + cos(2.0*a_*pi_*y)+ cos(2.0*a_*pi_*z))*dualVolume;
+  lhs[0] += 0.0;
+}
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/user_functions/SteadyThermalContactSrcElemSuppAlg.C
+++ b/src/user_functions/SteadyThermalContactSrcElemSuppAlg.C
@@ -97,8 +97,8 @@ SteadyThermalContactSrcElemSuppAlg::elem_execute(
   const int numScvIp = meSCV->numIntPoints_;
 
   // gather
-  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
-  int num_nodes = bulkData_->num_nodes(element);
+  stk::mesh::Entity const *  node_rels = realm_.begin_nodes_all(element);
+  int num_nodes = realm_.num_nodes_all(element);
 
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );


### PR DESCRIPTION
* To activate for instance for a P=3 simulation, use a Hex8 or Quad4 mesh and add a line under realms (e.g. below "use_edges")
-- "polynomial_order: 3"

* Two output files will be written, a regular output with only the original Hex8/Quad4 nodes, and a "fine" output which outputs subelements of the promoted topology

* Limited currently: only works with wall, inflow, and outflow bcs.  No shifted gauss points.

* Little effort to make the method P-scalable yet: setting P > 3 or 4 in 3D will make assembly time very large.  The memory usage is also very, very large.