### PR TITLE
Update higher order branch

### DIFF
--- a/include/ActuatorLine.h
+++ b/include/ActuatorLine.h
@@ -1,0 +1,249 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef ActuatorLine_h
+#define ActuatorLine_h
+
+#include <NaluParsing.h>
+#include<FieldTypeDef.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/Ghosting.hpp>
+#include <stk_search/BoundingBox.hpp>
+#include <stk_search/IdentProc.hpp>
+#include <stk_search/SearchMethod.hpp>
+
+// stk forwards
+/*namespace stk {
+  namespace mesh {
+    struct Entity;
+  }
+  }*/
+
+// basic c++
+#include <string>
+#include <vector>
+#include <utility>
+
+namespace sierra{
+namespace nalu{
+
+// common type defs
+typedef stk::search::IdentProc<uint64_t,int> theKey;
+typedef stk::search::Point<double> Point;
+typedef stk::search::Sphere<double> Sphere;
+typedef stk::search::Box<double> Box;
+typedef std::pair<Sphere,theKey> boundingSphere;
+typedef std::pair<Box,theKey> boundingElementBox;
+
+class Realm;
+
+class ActuatorLineInfo {
+public:
+  ActuatorLineInfo();
+  ~ActuatorLineInfo();
+
+  // for each type of probe, e.g., line of site, hold some stuff
+  int processorId_;
+  int numPoints_;
+  std::string turbineName_;
+  double radius_;
+  double omega_;
+  double twoSigSq_;
+  Coordinates coordinates_;
+};
+
+// class that holds all of the action... for each point, hold the 
+class ActuatorLinePointInfo {
+ public:
+  ActuatorLinePointInfo(size_t localId, Point centroidCoords, double radius, double omega, double twoSigSq);
+  ~ActuatorLinePointInfo();
+  size_t localId_;
+  Point centroidCoords_;
+  double radius_;
+  double omega_;
+  double twoSigSq_;
+  double bestX_;
+  stk::mesh::Entity bestElem_;
+  std::vector<double> isoParCoords_;
+  std::vector<stk::mesh::Entity> elementVec_;
+};
+ 
+class ActuatorLine
+{
+public:
+  
+  ActuatorLine(
+    Realm &realm,
+    const YAML::Node &node);
+  ~ActuatorLine();
+  
+  // load all of the options
+  void load(
+    const YAML::Node & node);
+
+  // setup part creation and nodal field registration (before populate_mesh())
+  void setup();
+
+  // setup part creation and nodal field registration (after populate_mesh())
+  void initialize();
+
+  // determine element bounding box in the mesh
+  void populate_candidate_elements();
+
+  // fill in the map that will hold point and ghosted elements
+  void create_actuator_line_point_info_map();
+
+  // possibly move the data points around
+  void set_current_coordinates();
+
+  // figure out the set of elements that belong in the custom ghosting data structure
+  void determine_elems_to_ghost();
+
+  // deal with custom ghosting
+  void manage_ghosting();
+
+  void set_current_coordinates(const double &omega);
+  void set_current_velocity(const double &omega);
+
+  // populate vector of elements
+  void complete_search();
+    
+  // populate nodal field and output norms (if appropriate)
+  void execute();
+
+  // support methods to gather data; scalar and vector
+  void resize_std_vector( 
+    const int &sizeOfField,
+    std::vector<double> &theVector,   
+    stk::mesh::Entity elem, 
+    const stk::mesh::BulkData & bulkData);
+
+  // general gather methods for scalar and vector (both double)
+  void gather_field(
+    const int &sizeOfField,
+    double *fieldToFill, 
+    const stk::mesh::FieldBase &stkField,
+    stk::mesh::Entity const* elem_node_rels, 
+    const int &nodesPerElement);
+
+  void gather_field_for_interp(
+    const int &sizeOfField,
+    double *fieldToFill, 
+    const stk::mesh::FieldBase &stkField,
+    stk::mesh::Entity const* elem_node_rels, 
+    const int &nodesPerElement);
+
+  // element volume and scv volume populated
+  double compute_volume( 
+    const int &nDim,
+    stk::mesh::Entity elem, 
+    const stk::mesh::BulkData & bulkData);
+
+  // interpolate field to point centroid
+  void interpolate_field(
+    const int &sizeOfField,
+    stk::mesh::Entity elem, 
+    const stk::mesh::BulkData & bulkData,
+    double *isoParCoords,
+    const double *fieldAtNodes,
+    double *pointField);
+
+  // drag at the point centroid
+  void compute_point_drag( 
+    const int &nDim, 
+    const double &pointRadius,
+    const double *pointGasVelocity,
+    const double &pointGasViscosity,
+    const double &pointGasDensity, 
+    double *pointDrag,
+    double &pointDragLHS);
+
+  // centroid of the element
+  void compute_elem_centroid( 
+    const int &nDim,
+    double *elemCentroid,
+    const int &nodesPerElement);
+
+  // radius from element centroid to point centroid
+  double compute_radius( 
+    const int &nDim,
+    const double *elemCentroid,
+    const double *pointCentroid);
+
+  // drag fource at given radius
+  void compute_elem_drag_given_radius( 
+    const int &nDim,
+    const double &radius, 
+    const double &twoSigSq, 
+    const double *pointDrag,
+    double *elemDrag);
+
+  // finally, perform the assembly
+  void assemble_source_to_nodes(
+    const int &nDim,
+    stk::mesh::Entity elem, 
+    const stk::mesh::BulkData & bulkData,
+    const double &elemVolume,
+    const double *drag,
+    const double &dragLHS,
+    stk::mesh::FieldBase &actuator_line_source,
+    stk::mesh::FieldBase &actuator_line_source_lhs,
+    const double &lhsFac); 
+
+  // hold the realm
+  Realm &realm_;
+
+  // type of stk search
+  stk::search::SearchMethod searchMethod_;
+  
+  // custom ghosting
+  stk::mesh::Ghosting *actuatorLineGhosting_;
+
+  // how many elements to ghost?
+  uint64_t needToGhostCount_;
+  stk::mesh::EntityProcVec elemsToGhost_;
+  
+  // local id for set of points
+  uint64_t localPointId_;
+
+  // does the actuator line move?
+  const bool actuatorLineMotion_;
+
+  // everyone needs pi
+  const double pi_;
+
+  // save off product of search
+  std::vector<std::pair<theKey, theKey> > searchKeyPair_;
+
+  // bounding box data types for stk_search */
+  std::vector<boundingSphere> boundingSphereVec_;
+  std::vector<boundingElementBox> boundingElementBoxVec_;
+
+  // target names for set of bounding boxes
+  std::vector<std::string> searchTargetNames_;
+ 
+  // vector of averaging information
+  std::vector<ActuatorLineInfo *> actuatorLineInfo_; 
+
+  // map of point info objects
+  std::map<size_t, ActuatorLinePointInfo *> actuatorLinePointInfoMap_;
+
+  // scratch space
+  std::vector<double> ws_coordinates_;
+  std::vector<double> ws_scv_volume_;
+  std::vector<double> ws_velocity_;
+  std::vector<double> ws_density_;
+  std::vector<double> ws_viscosity_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/AveragingInfo.h
+++ b/include/AveragingInfo.h
@@ -38,6 +38,8 @@ public:
   // specialty options
   bool computeReynoldsStress_;
   bool computeTke_;
+  bool computeFavreStress_;
+  bool computeFavreTke_;
 
   // vector of part names, e.g., block_1, surface_2
   std::vector<std::string> targetNames_;

--- a/include/ContinuityMassElemSuppAlg.h
+++ b/include/ContinuityMassElemSuppAlg.h
@@ -6,8 +6,8 @@
 /*------------------------------------------------------------------------*/
 
 
-#ifndef ContinuityMassBDF2ElemSuppAlg_h
-#define ContinuityMassBDF2ElemSuppAlg_h
+#ifndef ContinuityMassElemSuppAlg_h
+#define ContinuityMassElemSuppAlg_h
 
 #include <SupplementalAlgorithm.h>
 #include <FieldTypeDef.h>
@@ -21,14 +21,14 @@ namespace nalu{
 class Realm;
 class MasterElement;
 
-class ContinuityMassBDF2ElemSuppAlg : public SupplementalAlgorithm
+class ContinuityMassElemSuppAlg : public SupplementalAlgorithm
 {
 public:
 
-  ContinuityMassBDF2ElemSuppAlg(
+  ContinuityMassElemSuppAlg(
     Realm &realm);
 
-  virtual ~ContinuityMassBDF2ElemSuppAlg() {}
+  virtual ~ContinuityMassElemSuppAlg() {}
 
   virtual void setup();
 

--- a/include/MaterialPropertys.h
+++ b/include/MaterialPropertys.h
@@ -44,8 +44,6 @@ public:
   
   void breadboard(){};
   
-  void switch_to_super_element_target_names();
-
   // ease of access methods to particular initial condition
   size_t size() {return materialPropertyVector_.size();}
   MaterialProperty *operator[](int i) { return materialPropertyVector_[i];}

--- a/include/MomentumActuatorLineSrcNodeSuppAlg.h
+++ b/include/MomentumActuatorLineSrcNodeSuppAlg.h
@@ -1,0 +1,47 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef MomentumActuatorLineSrcNodeSuppAlg_h
+#define MomentumActuatorLineSrcNodeSuppAlg_h
+
+#include <SupplementalAlgorithm.h>
+#include <FieldTypeDef.h>
+
+#include <stk_mesh/base/Entity.hpp>
+
+namespace sierra{
+namespace nalu{
+
+class Realm;
+
+class MomentumActuatorLineSrcNodeSuppAlg : public SupplementalAlgorithm
+{
+public:
+
+  MomentumActuatorLineSrcNodeSuppAlg(
+    Realm &realm);
+
+  virtual ~MomentumActuatorLineSrcNodeSuppAlg() {}
+
+  virtual void setup();
+
+  virtual void node_execute(
+    double *lhs,
+    double *rhs,
+    stk::mesh::Entity node);
+  
+  VectorFieldType *actuatorLineSrc_;
+  ScalarFieldType *actuatorLineSrcLHS_;
+  ScalarFieldType *dualNodalVolume_;
+  int nDim_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/MomentumKeNSOElemSuppAlg.h
+++ b/include/MomentumKeNSOElemSuppAlg.h
@@ -61,7 +61,7 @@ public:
   const double fourthFac_;
 
   // fixed space
-  std::vector<double> ws_vrtmScs_;
+  std::vector<double> ws_rhoVrtmScs_;
   std::vector<double> ws_uNp1Scs_;
   std::vector<double> ws_dpdxScs_;
   std::vector<double> ws_GjpScs_;

--- a/include/MomentumMassElemSuppAlg.h
+++ b/include/MomentumMassElemSuppAlg.h
@@ -1,0 +1,85 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef MomentumMassElemSuppAlg_h
+#define MomentumMassElemSuppAlg_h
+
+#include <SupplementalAlgorithm.h>
+#include <FieldTypeDef.h>
+
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Entity.hpp>
+
+namespace sierra{
+namespace nalu{
+
+class Realm;
+class MasterElement;
+
+class MomentumMassElemSuppAlg : public SupplementalAlgorithm
+{
+public:
+
+  MomentumMassElemSuppAlg(
+    Realm &realm);
+
+  virtual ~MomentumMassElemSuppAlg() {}
+
+  virtual void setup();
+
+  virtual void elem_resize(
+    MasterElement *meSCS,
+    MasterElement *meSCV);
+
+  virtual void elem_execute(
+    double *lhs,
+    double *rhs,
+    stk::mesh::Entity element,
+    MasterElement *meSCS,
+    MasterElement *meSCV);
+  
+  const stk::mesh::BulkData *bulkData_;
+
+  VectorFieldType *velocityNm1_;
+  VectorFieldType *velocityN_;
+  VectorFieldType *velocityNp1_;
+  ScalarFieldType *densityNm1_;
+  ScalarFieldType *densityN_;
+  ScalarFieldType *densityNp1_;
+  VectorFieldType *Gjp_;
+  VectorFieldType *coordinates_;
+
+  double dt_;
+  double gamma1_;
+  double gamma2_;
+  double gamma3_;
+  const int nDim_;
+  const bool useShifted_;
+
+  // scratch space
+  std::vector<double> uNm1Scv_;
+  std::vector<double> uNScv_;
+  std::vector<double> uNp1Scv_;
+  std::vector<double> GjpScv_;
+
+  std::vector<double> ws_shape_function_;
+  std::vector<double> ws_uNm1_;
+  std::vector<double> ws_uN_;
+  std::vector<double> ws_uNp1_;
+  std::vector<double> ws_Gjp_;
+  std::vector<double> ws_rhoNm1_;
+  std::vector<double> ws_rhoN_;
+  std::vector<double> ws_rhoNp1_;
+  std::vector<double> ws_coordinates_;
+  std::vector<double> ws_scv_volume_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/MomentumNSOElemSuppAlg.h
+++ b/include/MomentumNSOElemSuppAlg.h
@@ -76,8 +76,7 @@ public:
 
   // fixed space
   std::vector<double> ws_dukdxScs_;
-  std::vector<double> ws_rhovScs_;
-  std::vector<double> ws_vrtmScs_;
+  std::vector<double> ws_rhoVrtmScs_;
   std::vector<double> ws_dpdxScs_;
   std::vector<double> ws_kd_;
 

--- a/include/MomentumNSOGradElemSuppAlg.h
+++ b/include/MomentumNSOGradElemSuppAlg.h
@@ -6,8 +6,8 @@
 /*------------------------------------------------------------------------*/
 
 
-#ifndef MomentumMassBackwardEulerElemSuppAlg_h
-#define MomentumMassBackwardEulerElemSuppAlg_h
+#ifndef MomentumNSOGradElemSuppAlg_h
+#define MomentumNSOGradElemSuppAlg_h
 
 #include <SupplementalAlgorithm.h>
 #include <FieldTypeDef.h>
@@ -21,14 +21,17 @@ namespace nalu{
 class Realm;
 class MasterElement;
 
-class MomentumMassBackwardEulerElemSuppAlg : public SupplementalAlgorithm
+class MomentumNSOGradElemSuppAlg : public SupplementalAlgorithm
 {
 public:
 
-  MomentumMassBackwardEulerElemSuppAlg(
-    Realm &realm);
+  MomentumNSOGradElemSuppAlg(
+    Realm &realm,
+    VectorFieldType *velocity,
+    GenericFieldType *Gju,
+    const double fourthFac);
 
-  virtual ~MomentumMassBackwardEulerElemSuppAlg() {}
+  virtual ~MomentumNSOGradElemSuppAlg() {}
 
   virtual void setup();
 
@@ -45,30 +48,42 @@ public:
   
   const stk::mesh::BulkData *bulkData_;
 
-  VectorFieldType *velocityN_;
   VectorFieldType *velocityNp1_;
-  ScalarFieldType *densityN_;
   ScalarFieldType *densityNp1_;
+  ScalarFieldType *pressure_;
   VectorFieldType *Gjp_;
+  VectorFieldType *velocityRTM_;
   VectorFieldType *coordinates_;
+  GenericFieldType *Gju_;
 
-  double dt_;
   const int nDim_;
-  const bool useShifted_;
+  const double Cupw_;
+  const double small_;
+  const double fourthFac_;
 
-  // scratch space
-  std::vector<double> uNScv_;
-  std::vector<double> uNp1Scv_;
-  std::vector<double> GjpScv_;
+  // fixed space
+  std::vector<double> ws_dukdxScs_;
+  std::vector<double> ws_rhoVrtmScs_;
+  std::vector<double> ws_dpdxScs_;
+  std::vector<double> ws_GjpScs_;
 
+  // scratch space; geometry
+  std::vector<double> ws_scs_areav_;
+  std::vector<double> ws_dndx_;
+  std::vector<double> ws_deriv_;
+  std::vector<double> ws_det_j_;
   std::vector<double> ws_shape_function_;
-  std::vector<double> ws_uN_;
+  std::vector<double> ws_gUpper_;
+  std::vector<double> ws_gLower_;
+
+  // scratch space; fields
   std::vector<double> ws_uNp1_;
-  std::vector<double> ws_Gjp_;
-  std::vector<double> ws_rhoN_;
   std::vector<double> ws_rhoNp1_;
+  std::vector<double> ws_pressure_;
+  std::vector<double> ws_Gjp_;
+  std::vector<double> ws_velocityRTM_;
   std::vector<double> ws_coordinates_;
-  std::vector<double> ws_scv_volume_;
+  std::vector<double> ws_Gju_;
 };
 
 } // namespace nalu

--- a/include/ScalarElemDiffusionFunctor.h
+++ b/include/ScalarElemDiffusionFunctor.h
@@ -446,31 +446,21 @@ public:
 
     // integrate over the IPs
     // Needs to be done for each node (?) for the LHS
-    int node_offset = 0;
-    for (int ic = 0; ic < nodesPerElement_; ++ic) {
-      int line_offset = 0;
-      for (int lineNumber = 0; lineNumber < numLines_; ++lineNumber) {
-        if (nDim_ == 2) {
-          quadOp_->surface_2D(p_lhs_integrand_, p_lhs_integrated_, node_offset+line_offset);
-        }
-        else {
-          quadOp_->surface_3D(p_lhs_integrand_, p_lhs_integrated_, node_offset+line_offset);
-        }
-        line_offset += ipsPerFace_;
+    if (nDim_ == 2) {
+      int node_offset = 0;
+      for (int ic = 0; ic < nodesPerElement_; ++ic) {
+        quadOp_->surfaces_2D(p_lhs_integrand_ + node_offset,  p_lhs_integrated_ + node_offset);
+        node_offset += numScsIp_;
       }
-      node_offset += numScsIp_;
+      quadOp_->surfaces_2D(p_rhs_integrand_, p_rhs_integrated_);
     }
-
-    // RHS
-    int line_offset = 0;
-    for (int lineNumber = 0; lineNumber < numLines_; ++lineNumber) {
-      if (nDim_ == 2) {
-        quadOp_->surface_2D(p_rhs_integrand_, p_rhs_integrated_, line_offset);
+    else {
+      int node_offset = 0;
+      for (int ic = 0; ic < nodesPerElement_; ++ic) {
+        quadOp_->surfaces_3D(p_lhs_integrand_ + node_offset,  p_lhs_integrated_ + node_offset);
+        node_offset += numScsIp_;
       }
-      else {
-        quadOp_->surface_3D(p_rhs_integrand_, p_rhs_integrated_, line_offset);
-      }
-      line_offset += ipsPerFace_;
+      quadOp_->surfaces_3D(p_rhs_integrand_, p_rhs_integrated_);
     }
 
     // scatter

--- a/include/ScalarKeNSOElemSuppAlg.h
+++ b/include/ScalarKeNSOElemSuppAlg.h
@@ -65,7 +65,7 @@ public:
   const double fourthFac_;
 
   // fixed space
-  std::vector<double> ws_vrtmScs_;
+  std::vector<double> ws_rhoVrtmScs_;
   std::vector<double> ws_uNp1Scs_;
   std::vector<double> ws_dpdxScs_;
   std::vector<double> ws_GjpScs_;

--- a/include/ScalarMassElemSuppAlg.h
+++ b/include/ScalarMassElemSuppAlg.h
@@ -1,0 +1,79 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef ScalarMassElemSuppAlg_h
+#define ScalarMassElemSuppAlg_h
+
+#include <SupplementalAlgorithm.h>
+#include <FieldTypeDef.h>
+
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Entity.hpp>
+
+namespace sierra{
+namespace nalu{
+
+class Realm;
+class MasterElement;
+
+class ScalarMassElemSuppAlg : public SupplementalAlgorithm
+{
+public:
+
+  ScalarMassElemSuppAlg(
+    Realm &realm,
+    ScalarFieldType *scalarQ);
+
+  virtual ~ScalarMassElemSuppAlg() {}
+
+  virtual void setup();
+
+  virtual void elem_resize(
+    MasterElement *meSCS,
+    MasterElement *meSCV);
+
+  virtual void elem_execute(
+    double *lhs,
+    double *rhs,
+    stk::mesh::Entity element,
+    MasterElement *meSCS,
+    MasterElement *meSCV);
+  
+  const stk::mesh::BulkData *bulkData_;
+
+  ScalarFieldType *scalarQNm1_;
+  ScalarFieldType *scalarQN_;
+  ScalarFieldType *scalarQNp1_;
+  ScalarFieldType *densityNm1_;
+  ScalarFieldType *densityN_;
+  ScalarFieldType *densityNp1_;
+  VectorFieldType *coordinates_;
+
+  double dt_;
+  double gamma1_;
+  double gamma2_;
+  double gamma3_;
+  const int nDim_;
+  const bool useShifted_;
+
+  // scratch space
+  std::vector<double> ws_shape_function_;
+  std::vector<double> ws_qNm1_;
+  std::vector<double> ws_qN_;
+  std::vector<double> ws_qNp1_;
+  std::vector<double> ws_rhoNm1_;
+  std::vector<double> ws_rhoN_;
+  std::vector<double> ws_rhoNp1_;
+  std::vector<double> ws_coordinates_;
+  std::vector<double> ws_scv_volume_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/ScalarNSOElemSuppAlg.h
+++ b/include/ScalarNSOElemSuppAlg.h
@@ -75,8 +75,7 @@ public:
 
   // fixed space
   std::vector<double> ws_dqdxScs_;
-  std::vector<double> ws_vrtmScs_;
-  std::vector<double> ws_rhovScs_;
+  std::vector<double> ws_rhoVrtmScs_;
 
   // scratch space; geometry
   std::vector<double> ws_scs_areav_;

--- a/include/SolutionNormPostProcessing.h
+++ b/include/SolutionNormPostProcessing.h
@@ -37,7 +37,8 @@ class SolutionNormPostProcessing
 public:
   
   SolutionNormPostProcessing(
-    Realm &realm);
+    Realm &realm,
+    const YAML::Node &node);
   ~SolutionNormPostProcessing();
   
   // load all of the options
@@ -45,8 +46,7 @@ public:
     const YAML::Node & node);
 
   // setup nodal field registration; algorithms
-  void setup(
-    const std::vector<std::string> targetNames);
+  void setup();
 
   // create the algorithm to populate the exact field
   void analytical_function_factory(

--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -125,6 +125,7 @@ private:
 
   typedef std::pair<stk::mesh::Entity, stk::mesh::Entity> Connection;
   typedef std::set< Connection > ConnectionSet;
+  typedef std::vector< Connection > ConnectionVec;
   ConnectionSet connectionSet_;
   std::vector<GlobalOrdinal> totalGids_;
 

--- a/include/TurbulenceAveragingPostProcessing.h
+++ b/include/TurbulenceAveragingPostProcessing.h
@@ -23,6 +23,7 @@ namespace stk {
     class MetaData;
     class Part;
     typedef std::vector<Part*> PartVector;
+    class Selector;
   }
 }
 
@@ -48,7 +49,7 @@ public:
   // setup nodal field registration; parts, fields, etc
   void setup();
 
-  void register_field(
+  void register_field_from_primitive(
     const std::string primitiveName,
     const std::string averagedName,
     stk::mesh::MetaData &metaData,
@@ -61,11 +62,37 @@ public:
     std::vector<unsigned> &fieldSizeVec_,
     stk::mesh::MetaData &metaData);
 
+  void register_field(
+    const std::string fieldName,
+    const int fieldSize,
+    stk::mesh::MetaData &metaData,
+    stk::mesh::Part *targetPart);
+
   void review( 
     const AveragingInfo *avInfo);
 
   // populate nodal field and output norms (if appropriate)
   void execute();
+
+  // compute tke and stress for each type of operation
+  void compute_tke(
+    const bool isReynolds,
+    const std::string &averageBlockName,
+    stk::mesh::Selector s_all_nodes);
+
+  void compute_reynolds_stress(
+    const std::string &averageBlockName,
+    const double &oldTimeFilter,
+    const double &zeroCurrent,
+    const double &dt,
+    stk::mesh::Selector s_all_nodes);
+
+  void compute_favre_stress(
+    const std::string &averageBlockName,
+    const double &oldTimeFilter,
+    const double &zeroCurrent,
+    const double &dt,
+    stk::mesh::Selector s_all_nodes);
 
   // hold the realm
   Realm &realm_;

--- a/include/element_promotion/ElementCondenser.h
+++ b/include/element_promotion/ElementCondenser.h
@@ -1,0 +1,78 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+#ifndef ElementCondenser_h
+#define ElementCondenser_h
+
+#include <Teuchos_BLAS.hpp>
+#include <Teuchos_LAPACK.hpp>
+#include <Teuchos_SerialDenseVector.hpp>
+#include <Teuchos_SerialDenseMatrix.hpp>
+#include <Teuchos_SerialDenseSolver.hpp>
+
+
+namespace sierra {
+namespace nalu {
+
+  struct ElementDescription;
+
+  class ElementCondenser
+  {
+  public:
+    ElementCondenser(const ElementDescription& elem);
+
+    void condense(
+      double* lhs,
+      const double* rhs,
+      double* r_lhs,
+      double* r_rhs
+    );
+
+    void compute_interior_update(
+      double* lhs,
+      const double* boundary_values,
+      const double* rhs,
+      double* interior_values
+    );
+
+    int num_boundary_nodes()
+    {
+      return nb_;
+    }
+
+    int num_internal_nodes()
+    {
+      return ni_;
+    }
+
+    int nodes_per_element()
+    {
+      return ne_;
+    }
+
+  private:
+    void chunk(const double* lhs, const double* rhs, double* b_lhs, double* b_rhs);
+    void chunk_lower(const double* lhs, const double* rhs);
+
+    Teuchos::BLAS<int,double> blas_;
+    Teuchos::LAPACK<int,double> lapack_;
+
+    std::vector<double> lhsBB_;
+    std::vector<double> lhsIB_;
+    std::vector<double> lhsBI_;
+    std::vector<double> lhsII_;
+    std::vector<double> rhsI_;
+    std::vector<int> ipiv_;
+    int nb_;
+    int ni_;
+    int ne_;
+
+  };
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/element_promotion/ElementDescription.h
+++ b/include/element_promotion/ElementDescription.h
@@ -1,3 +1,10 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level nalu      */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
 #ifndef ElementDescription_h
 #define ElementDescription_h
 
@@ -19,30 +26,35 @@ typedef std::vector<std::vector<size_t>> SubElementConnectivity;
 struct ElementDescription
 {
 public:
-  static std::unique_ptr<ElementDescription> create(int dimension, int order, std::string quadType = "GaussLegendre");
+  static std::unique_ptr<ElementDescription> create(
+    int dimension,
+    int order,
+    std::string quadType = "GaussLegendre",
+    bool useReducedGeometricBasis = false
+  );
   virtual ~ElementDescription() = default;
 
-  inline int tensor_product_node_map(int i, int j, int k) const
+  int tensor_product_node_map(int i, int j, int k) const
   {
     return nodeMap[i+nodes1D*(j+nodes1D*k)];
   }
 
-  inline int tensor_product_node_map(int i, int j) const
+  int tensor_product_node_map(int i, int j) const
   {
     return nodeMap[i+nodes1D*j];
   }
 
-  inline int tensor_product_node_map_bc(int i, int j) const
+  int tensor_product_node_map_bc(int i, int j) const
   {
     return nodeMapBC[i+nodes1D*j];
   }
 
-  inline int tensor_product_node_map_bc(int i) const
+  int tensor_product_node_map_bc(int i) const
   {
     return nodeMapBC[i];
   }
 
-  inline int tensor_index(int nodeNumber) const
+  int tensor_index(int nodeNumber) const
   {
     const auto& ords = inverseNodeMap[nodeNumber];
     if (dimension == 2) {
@@ -51,39 +63,47 @@ public:
     return (ords[0] + nodes1D*(ords[1]+nodes1D*ords[2]));
   }
 
-  inline double gauss_point_location(
+  const int* side_ordinals_for_face(int face_ordinal) const {
+    return sideOrdinalMap[face_ordinal].data();
+  }
+
+  int side_ordinal(int face_ordinal, int node_ordinal_index) const {
+    return sideOrdinalMap[face_ordinal][node_ordinal_index];
+  }
+
+  double gauss_point_location(
     int nodeOrdinal,
     int gaussPointOrdinal) const
   {
     return quadrature->gauss_point_location(nodeOrdinal,gaussPointOrdinal);
   }
 
-  inline double tensor_product_weight(
+  double tensor_product_weight(
     int s1Node, int s2Node, int s3Node,
     int s1Ip, int s2Ip, int s3Ip) const
   {
     return quadrature->tensor_product_weight(s1Node,s2Node,s3Node,s1Ip,s2Ip,s3Ip);
   }
 
-  inline double tensor_product_weight(
+  double tensor_product_weight(
     int s1Node, int s2Node,
     int s1Ip, int s2Ip) const
   {
     return quadrature->tensor_product_weight(s1Node,s2Node, s1Ip,s2Ip);
   }
 
-  inline double tensor_product_weight(int s1Node, int s1Ip) const
+  double tensor_product_weight(int s1Node, int s1Ip) const
   {
     return quadrature->tensor_product_weight(s1Node, s1Ip);
   }
 
-  inline std::vector<double>
+  std::vector<double>
   eval_basis_weights(const std::vector<double>& intgLoc) const
   {
      return basis->eval_basis_weights(intgLoc);
   }
 
-  inline std::vector<double>
+  std::vector<double>
   eval_deriv_weights(const std::vector<double>& intgLoc) const
   {
     return basis->eval_deriv_weights(intgLoc);
@@ -94,8 +114,8 @@ public:
 
   size_t dimension;
   size_t nodes1D;
-  size_t nodesPerFace;
   size_t nodesPerElement;
+  size_t nodesPerFace;
   size_t nodesInBaseElement;
   size_t nodesPerSubElement;
   AddedConnectivityOrdinalMap addedConnectivities;
@@ -106,17 +126,19 @@ public:
   SubElementConnectivity subElementConnectivity;
 
   std::string quadType;
+  bool useReducedGeometricBasis;
   unsigned polyOrder;
   unsigned numQuad;
   std::unique_ptr<TensorProductQuadratureRule> quadrature;
   std::unique_ptr<LagrangeBasis> basis;
   std::unique_ptr<LagrangeBasis> basisBoundary;
+  std::unique_ptr<LagrangeBasis> linearBasis;
   std::vector<unsigned> nodeMap;
   std::vector<unsigned> nodeMapBC;
   std::vector<std::vector<unsigned>> inverseNodeMap;
   std::vector<std::vector<unsigned>> inverseNodeMapBC;
   std::vector<std::vector<size_t>> faceNodeMap;
-  std::vector<std::vector<size_t>> sideOrdinalMap;
+  std::vector<std::vector<int>> sideOrdinalMap;
 protected:
   ElementDescription() = default;
 };
@@ -124,7 +146,12 @@ protected:
 struct QuadMElementDescription: public ElementDescription
 {
 public:
-  QuadMElementDescription(std::vector<double> in_nodeLocs, std::vector<double> in_scsLoc, std::string quadType);
+  QuadMElementDescription(
+    std::vector<double> nodeLocs,
+    std::vector<double> scsLoc,
+    std::string quadType,
+    bool useReducedGeometricBasis
+  );
 private:
   void set_node_connectivity();
   void set_subelement_connectivity();
@@ -133,7 +160,12 @@ private:
 struct HexMElementDescription: public ElementDescription
 {
 public:
-  HexMElementDescription(std::vector<double> in_nodeLocs, std::vector<double> in_scsLoc, std::string quadType);
+  HexMElementDescription(
+    std::vector<double> nodeLocs,
+    std::vector<double> scsLoc,
+    std::string quadType,
+    bool useReducedGeometricBasis
+  );
 private:
   void set_node_connectivity();
   void set_subelement_connectivity();

--- a/include/element_promotion/MasterElement.h
+++ b/include/element_promotion/MasterElement.h
@@ -1,0 +1,184 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef MasterElement_h
+#define MasterElement_h
+
+#include <stdexcept>
+#include <vector>
+
+namespace sierra{
+namespace naluUnit{
+
+namespace Jacobian{
+enum Direction
+  {
+    S_DIRECTION = 0,
+    T_DIRECTION = 1,
+    U_DIRECTION = 2
+  };
+  }
+
+class MasterElement
+{
+public:
+
+  MasterElement();
+  virtual ~MasterElement();
+
+  virtual void determinant(
+    const int nelem,
+    const double *coords,
+    double *volume,
+    double * error ) {
+    throw std::runtime_error("determinant not implemented");}
+
+  virtual void grad_op(
+    const int nelem,
+    const double *coords,
+    double *gradop,
+    double *deriv,
+    double *det_j,
+    double * error ) {
+    throw std::runtime_error("grad_op not implemented");}
+
+  virtual void shifted_grad_op(
+    const int nelem,
+    const double *coords,
+    double *gradop,
+    double *deriv,
+    double *det_j,
+    double * error ) {
+    throw std::runtime_error("grad_op not implemented");}
+
+  virtual void gij(
+    const double *coords,
+    double *gupperij,
+    double *glowerij,
+    double *deriv) {
+    throw std::runtime_error("gij not implemented");}
+
+  virtual void nodal_grad_op(
+    const int nelem,
+    double *deriv,
+    double * error ) {
+    throw std::runtime_error("nodal_grad_op not implemented");}
+
+  virtual void face_grad_op(
+    const int nelem,
+    const int face_ordinal,
+    const double *coords,
+    double *gradop,
+    double *det_j,
+    double * error ) {
+    throw std::runtime_error("face_grad_op not implemented; avoid this element type at open bcs, walls and symms");}
+
+  virtual const int * adjacentNodes() {
+    throw std::runtime_error("adjacentNodes not implementedunknown bc");
+    return NULL;}
+
+  virtual const int * ipNodeMap(int ordinal = 0) {
+    throw std::runtime_error("ipNodeMap not implemented");
+    return NULL;}
+
+  virtual void shape_fcn(
+    double *shpfc) {
+    throw std::runtime_error("shape_fcn not implemented"); }
+
+  virtual void shifted_shape_fcn(
+    double *shpfc) {
+    throw std::runtime_error("shifted_shape_fcn not implemented"); }
+
+  virtual int opposingNodes(
+    const int ordinal, const int node) {
+    throw std::runtime_error("adjacentNodes not implemented"); }
+
+  virtual int opposingFace(
+    const int ordinal, const int node) {
+    throw std::runtime_error("opposingFace not implemented");
+    return 0; }
+
+  virtual double isInElement(
+    const double *elemNodalCoord,
+    const double *pointCoord,
+    double *isoParCoord) {
+    throw std::runtime_error("isInElement not implemented");
+    return 1.0e6; }
+
+  virtual void interpolatePoint(
+    const int &nComp,
+    const double *isoParCoord,
+    const double *field,
+    double *result) {
+    throw std::runtime_error("interpolatePoint not implemented"); }
+
+  virtual void general_shape_fcn(
+    const int numIp,
+    const double *isoParCoord,
+    double *shpfc) {
+    throw std::runtime_error("general_shape_fcn not implement"); }
+
+  virtual void general_face_grad_op(
+    const int face_ordinal,
+    const double *isoParCoord,
+    const double *coords,
+    double *gradop,
+    double *det_j,
+    double * error ) {
+    throw std::runtime_error("general_face_grad_op not implemented");}
+
+  virtual void sidePcoords_to_elemPcoords(
+    const int & side_ordinal,
+    const int & npoints,
+    const double *side_pcoords,
+    double *elem_pcoords) {
+    throw std::runtime_error("sidePcoords_to_elemPcoords");}
+
+  virtual const int * faceNodeOnExtrudedElem() {
+    throw std::runtime_error("faceNodeOnExtrudedElem not implement"); }
+
+  virtual const int * opposingNodeOnExtrudedElem() {
+    throw std::runtime_error("opposingNodeOnExtrudedElem not implement"); }
+
+  virtual const int * faceScsIpOnExtrudedElem() {
+    throw std::runtime_error("faceScsIpOnExtrudedElem not implement"); }
+
+  virtual const int * faceScsIpOnFaceEdges() {
+    throw std::runtime_error("faceScsIpOnFaceEdges not implement"); }
+
+  virtual const double * edgeAlignedArea() {
+    throw std::runtime_error("edgeAlignedArea not implement"); }
+
+  double isoparametric_mapping(const double b, const double a, const double xi) const;
+
+  int nDim_;
+  int nodesPerElement_;
+  int numIntPoints_;
+  double scaleToStandardIsoFac_;
+
+  std::vector<int> lrscv_;
+  std::vector<int> ipNodeMap_;
+  std::vector<int> oppNode_;
+  std::vector<int> oppFace_;
+  std::vector<double> intgLoc_;
+  std::vector<double> intgLocShift_;
+  std::vector<double> intgExpFace_;
+  std::vector<double> nodeLoc_;
+  // extrusion-based scheme
+  std::vector<int> faceNodeOnExtrudedElem_;
+  std::vector<int> opposingNodeOnExtrudedElem_;
+  std::vector<int> faceScsIpOnExtrudedElem_;
+  std::vector<int> faceScsIpOnFaceEdges_;
+  std::vector<double> edgeAlignedArea_;
+
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/include/element_promotion/MasterElementHO.h
+++ b/include/element_promotion/MasterElementHO.h
@@ -19,10 +19,9 @@ namespace nalu{
     double weight;
   };
 
-// 2D Quad 16 subcontrol volume
 struct ElementDescription;
 
-class HigherOrderHexSCV : public MasterElement
+class HigherOrderHexSCV final: public MasterElement
 {
 public:
   HigherOrderHexSCV(const ElementDescription& elem);
@@ -37,21 +36,23 @@ public:
     double *volume,
     double * error ) final;
 
-  const ElementDescription& elem_;
-  std::vector<double> ipWeight_;
-  std::vector<double> shapeFunctions_;
-  std::vector<double> shapeDerivs_;
-
 private:
   void set_interior_info();
 
   double jacobian_determinant(
     const double *elemNodalCoords,
     const double *shapeDerivs ) const;
+
+  const ElementDescription& elem_;
+  std::vector<double> ipWeight_;
+  std::vector<double> shapeFunctions_;
+  std::vector<double> shapeDerivs_;
+  std::vector<double> geometricShapeDerivs_;
+  int geometricNodesPerElement_;
 };
 
 // 3D Hex 27 subcontrol surface
-class HigherOrderHexSCS : public MasterElement
+class HigherOrderHexSCS final: public MasterElement
 {
 public:
   HigherOrderHexSCS(const ElementDescription& elem);
@@ -63,7 +64,7 @@ public:
     const int nelem,
     const double *coords,
     double *areav,
-    double * error ) final;
+    double * error) final;
 
   void grad_op(
     const int nelem,
@@ -71,7 +72,7 @@ public:
     double *gradop,
     double *deriv,
     double *det_j,
-    double * error ) final;
+    double * error) final;
 
   void face_grad_op(
     const int nelem,
@@ -79,7 +80,7 @@ public:
     const double *coords,
     double *gradop,
     double *det_j,
-    double * error ) final;
+    double * error) final;
 
   void gij(
     const double *coords,
@@ -91,16 +92,15 @@ public:
 
   const int * ipNodeMap(int ordinal = 0) final;
 
+  const int * side_node_ordinals(int ordinal = 0) final;
+
   int opposingNodes(
     const int ordinal, const int node) final;
 
   int opposingFace(
     const int ordinal, const int node) final;
 
-  const ElementDescription& elem_;
-  std::vector<double> shapeFunctions_;
-  std::vector<double> shapeDerivs_;
-  std::vector<double> expFaceShapeDerivs_;
+
 
 private:
   void set_interior_info();
@@ -118,12 +118,25 @@ private:
     double* grad,
     double* det_j ) const;
 
+  void gradient(
+    const double* elemNodalCoords,
+    const double* geometricShapeDeriv,
+    const double* shapeDeriv,
+    double* grad,
+    double* det_j ) const;
+
+  const ElementDescription& elem_;
+  std::vector<double> shapeFunctions_;
+  std::vector<double> shapeDerivs_;
+  std::vector<double> expFaceShapeDerivs_;
+  std::vector<double> geometricShapeDerivs_;
+  int geometricNodesPerElement_;
   std::vector<ContourData> ipInfo_;
   int ipsPerFace_;
 };
 
 // 3D Quad 9
-class HigherOrderQuad3DSCS : public MasterElement
+class HigherOrderQuad3DSCS final: public MasterElement
 {
 public:
   HigherOrderQuad3DSCS(const ElementDescription& elem);
@@ -138,10 +151,6 @@ public:
     const double *coords,
     double *areav,
     double * error );
-
-  const ElementDescription& elem_;
-  std::vector<double> shapeFunctions_;
-  std::vector<double> shapeDerivs_;
 
 private:
   void set_interior_info();
@@ -165,11 +174,14 @@ private:
     double* deriv
   ) const;
 
+  const ElementDescription& elem_;
+  std::vector<double> shapeFunctions_;
+  std::vector<double> shapeDerivs_;
   std::vector<double> ipWeight_;
   int surfaceDimension_;
 };
 
-class HigherOrderQuad2DSCV : public MasterElement
+class HigherOrderQuad2DSCV final: public MasterElement
 {
 public:
   explicit HigherOrderQuad2DSCV(const ElementDescription& elem);
@@ -185,18 +197,21 @@ public:
     double *volume,
     double * error ) final;
 
-  const ElementDescription& elem_;
-  std::vector<double> ipWeight_;
-  std::vector<double> shapeFunctions_;
-  std::vector<double> shapeDerivs_;
 private:
   void set_interior_info();
 
   double jacobian_determinant(
     const double *elemNodalCoords,
     const double *shapeDerivs ) const;
+
+  const ElementDescription& elem_;
+  std::vector<double> ipWeight_;
+  std::vector<double> shapeFunctions_;
+  std::vector<double> shapeDerivs_;
+  std::vector<double> geometricShapeDerivs_;
+  int geometricNodesPerElement_;
 };
-class HigherOrderQuad2DSCS : public MasterElement
+class HigherOrderQuad2DSCS final: public MasterElement
 {
 public:
   explicit HigherOrderQuad2DSCS(const ElementDescription& elem);
@@ -242,7 +257,7 @@ public:
   int opposingFace(
     const int ordinal, const int node) final;
 
-  std::vector<double> shapeFunctions_;
+  const int * side_node_ordinals(int ordinal = 0) final;
 
 private:
   void set_interior_info();
@@ -260,16 +275,25 @@ private:
     double* grad,
     double* det_j) const;
 
+  void gradient(
+    const double* elemNodalCoords,
+    const double* geometricShapeDeriv,
+    const double* shapeDeriv,
+    double* grad,
+    double* det_j ) const;
 
   const ElementDescription& elem_;
+  std::vector<double> ipWeight_;
+  std::vector<double> shapeFunctions_;
+  std::vector<double> shapeDerivs_;
+  std::vector<double> geometricShapeDerivs_;
+  int geometricNodesPerElement_;
   std::vector<ContourData> ipInfo_;
   int ipsPerFace_;
-
-  std::vector<double> shapeDerivs_;
   std::vector<double> expFaceShapeDerivs_;
 };
 
-class HigherOrderEdge2DSCS : public MasterElement
+class HigherOrderEdge2DSCS final: public MasterElement
 {
 public:
   explicit HigherOrderEdge2DSCS(const ElementDescription& elem);
@@ -286,7 +310,6 @@ public:
   void shape_fcn(
     double *shpfc) final;
 
-  std::vector<double> shapeFunctions_;
 private:
   void area_vector(
     const double* elemNodalCoords,
@@ -295,7 +318,7 @@ private:
 
   const ElementDescription& elem_;
   std::vector<double> ipWeight_;
-
+  std::vector<double> shapeFunctions_;
   std::vector<double> shapeDerivs_;
 };
 

--- a/include/element_promotion/PromotedElementIO.h
+++ b/include/element_promotion/PromotedElementIO.h
@@ -1,3 +1,9 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level nalu      */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
 #ifndef PromotedElementIO_h
 #define PromotedElementIO_h
 
@@ -61,9 +67,16 @@ public:
 
   virtual ~PromotedElementIO() = default;
 
-  void output_results(const std::vector<const stk::mesh::FieldBase*> fields) const;
-
+  void add_fields(const std::vector<stk::mesh::FieldBase*>& fields);
   void write_database_data(double currentTime);
+
+  bool has_field(const std::string field_name)
+  {
+    return (fields_.find(field_name) != fields_.end());
+  }
+
+private:
+  void output_results(const std::vector<const stk::mesh::FieldBase*> fields) const;
 
   void write_element_connectivity(
     const stk::mesh::PartVector& baseParts,
@@ -79,15 +92,13 @@ public:
   void write_sideset_definitions(const stk::mesh::PartVector& baseParts);
   void write_coordinate_list(const stk::mesh::PartVector& superElemParts);
 
-  void add_fields(const std::vector<stk::mesh::FieldBase*>& fields);
   int maximum_field_length(const stk::mesh::FieldBase& field) const;
 
   template<typename T> void
   put_data_on_node_block(
     Ioss::NodeBlock& nodeBlock,
     const stk::mesh::FieldBase& field,
-    const stk::mesh::BucketVector& buckets,
-    size_t numNodes) const;
+    const stk::mesh::BucketVector& buckets) const;
 
   std::string storage_name(const stk::mesh::FieldBase& field) const;
 
@@ -98,30 +109,15 @@ public:
   const std::string& fileName_;
   const stk::mesh::FieldBase* coordinates_;
   const unsigned nDim_;
+  stk::mesh::PartVector superElemParts_;
 
-  struct FieldNameHash {
-    std::size_t operator()(const stk::mesh::FieldBase* const  field) const  {
-      return std::hash<std::string>()(field->name());
-    }
-  };
-
-  struct FieldNameEqual {
-    bool operator()(const stk::mesh::FieldBase* fieldA, const stk::mesh::FieldBase* fieldB) const {
-      return (fieldA->name() == fieldB->name());
-    }
-  };
-  std::unordered_set<const stk::mesh::FieldBase*, FieldNameHash, FieldNameEqual> fields_;
-
+  std::map<const std::string, const stk::mesh::FieldBase*> fields_;
   std::map<const stk::mesh::Part*, Ioss::ElementBlock*> elementBlockPointers_;
   std::map<const stk::mesh::Part*, Ioss::SideBlock*> sideBlockPointers_;
   Ioss::NodeBlock* nodeBlock_;
 
   std::unique_ptr<Ioss::Region> output_;
   Ioss::DatabaseIO* databaseIO;
-
-  // fields
-
-
 };
 
 } // namespace nalu

--- a/include/element_promotion/PromotedPartHelper.h
+++ b/include/element_promotion/PromotedPartHelper.h
@@ -24,24 +24,36 @@ namespace sierra {
 namespace nalu {
 
   bool part_vector_is_valid(const stk::mesh::PartVector& parts);
-  std::string promote_part_name(const std::string& base_name);
-  std::string super_element_part_name(const std::string& base_name);
-  stk::mesh::Part* promoted_part(const stk::mesh::Part& part);
+
+  bool check_parts_for_promotion(const stk::mesh::PartVector& parts);
+
+  std::string super_element_suffix();
+
+  std::string super_element_part_name(std::string base_name);
+
+  std::string super_subset_part_name(const std::string& base_name, int numElemNodes, int numSideNodes);
+
   stk::mesh::Part* super_elem_part(const stk::mesh::Part& part);
-  void transform_to_promoted_part_vector(stk::mesh::PartVector& parts);
+
+  stk::mesh::Part* super_subset_part(const stk::mesh::Part& part, int numElemNodes, int numSideNodes);
+
   void transform_to_super_elem_part_vector(stk::mesh::PartVector& parts);
-  stk::mesh::PartVector promote_part_vector(stk::mesh::PartVector parts);
+
   stk::mesh::PartVector super_elem_part_vector(const stk::mesh::PartVector& parts);
+
   stk::mesh::PartVector base_elem_parts(const stk::mesh::PartVector& parts);
+
   stk::mesh::Part* base_elem_part_from_super_elem_part(const stk::mesh::Part& super_elem_part);
+
+  stk::mesh::PartVector only_super_parts(const stk::mesh::PartVector& parts);
+
   stk::mesh::PartVector only_super_elem_parts(const stk::mesh::PartVector& parts);
+
+  stk::mesh::PartVector only_super_side_parts(const stk::mesh::PartVector& parts);
+
   stk::mesh::PartVector append_super_elems_to_part_vector(stk::mesh::PartVector parts);
 
-  size_t num_sub_elements(
-    const stk::mesh::MetaData& metaData,
-    const stk::mesh::BucketVector& buckets,
-    unsigned polyOrder
-  );
+  size_t num_sub_elements(const int dim, const stk::mesh::BucketVector& buckets, unsigned polyOrder);
 
   size_t count_entities(const stk::mesh::BucketVector& buckets);
 

--- a/include/element_promotion/QuadratureKernels.h
+++ b/include/element_promotion/QuadratureKernels.h
@@ -1,3 +1,9 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level nalu      */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
 #ifndef QuadratureKernels_h
 #define QuadratureKernels_h
 
@@ -25,21 +31,27 @@ namespace nalu {
       int line_offset);
 
     void surface_3D(
-      const double* __restrict__ integrand,
-      double* __restrict__ result,
+      const double* integrand,
+      double* result,
       int face_offset);
+
+    void surfaces_2D(const double* integrand, double* result);
+    void surfaces_3D(const double* integrand, double* result);
 
   private:
     const Teuchos::BLAS<int,double> blas_;
     int nodes1D_;
     int nodesPerElement_;
+    int numSurfaces_;
+    int nodesPerFace_;
+    int size3D_;
+
     std::vector<double> work2D_;
     std::vector<double> weightTensor_;
     std::vector<double> weightMatrix_;
     double* p_weightTensor_;
     double* p_weightMatrix_;
     double* p_work2D_;
-
   };
 
 } // namespace nalu

--- a/include/element_promotion/QuadratureRule.h
+++ b/include/element_promotion/QuadratureRule.h
@@ -13,12 +13,15 @@
 namespace sierra{
 namespace nalu{
 
+  // <abscissae, weights>
   std::pair<std::vector<double>, std::vector<double>>
   gauss_legendre_rule(int order);
 
+  // <abscissae, weights>
   std::pair<std::vector<double>, std::vector<double>>
   gauss_lobatto_legendre_rule(int order, double xleft = -1.0, double xright = +1.0);
 
+  // <abscissae, weights>
   std::pair<std::vector<double>, std::vector<double>>
   SGL_quadrature_rule(int order, std::vector<double> scsEndLocations);
 

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -159,7 +159,12 @@ public:
   virtual const double * edgeAlignedArea() {
     throw std::runtime_error("edgeAlignedArea not implement"); }
 
+  virtual const int * side_node_ordinals(int sideOrdinal) {
+    throw std::runtime_error("side_node_ordinals not implemented"); }
+
   double isoparametric_mapping(const double b, const double a, const double xi) const;
+  bool within_tolerance(const double & val, const double & tol);
+  double vector_norm_sq(const double * vect, int len);
 
   int nDim_;
   int nodesPerElement_;
@@ -174,6 +179,9 @@ public:
   std::vector<double> intgLocShift_;
   std::vector<double> intgExpFace_;
   std::vector<double> nodeLoc_;
+  std::vector<int> sideNodeOrdinals_;
+  std::vector<int> sideOffset_;
+
   // extrusion-based scheme
   std::vector<int> faceNodeOnExtrudedElem_;
   std::vector<int> opposingNodeOnExtrudedElem_;
@@ -209,6 +217,7 @@ public:
 
   void shape_fcn(
     double *shpfc);
+
 };
 
 // Hex 8 subcontrol surface
@@ -309,9 +318,9 @@ public:
   const double * edgeAlignedArea();
   
   // helper
-  double vector_norm( const double * vect, int len );
   double parametric_distance(const std::vector<double> &x);
-  bool within_tol( const double & val, const double & tol );
+
+  const int* side_node_ordinals(int sideOrdinal);
 };
 
 class HexahedralP2Element : public MasterElement
@@ -470,6 +479,8 @@ public:
   int opposingFace(
     const int ordinal, const int node);
 
+  const int* side_node_ordinals(int sideOrdinal);
+
 private:
   void set_interior_info();
   void set_boundary_info();
@@ -604,6 +615,8 @@ public:
 
   // helper
   double parametric_distance(const std::vector<double> &x);
+
+  const int* side_node_ordinals(int sideOrdinal);
 };
 
 // Pyramid 5 subcontrol volume
@@ -679,6 +692,8 @@ public:
 
   int opposingNodes(
     const int ordinal, const int node);
+
+  const int* side_node_ordinals(int sideOrdinal);
 };
 
 // Wedge 6 subcontrol volume
@@ -778,10 +793,10 @@ public:
     double* shape_fcn);
 
   // helper functions to isInElement
-  bool within_tolerance( const double & val, const double & tol );
-  double vector_norm_sq( const double *theVector );
   double parametric_distance( const double X, const double Y);
   double parametric_distance( const std::vector<double> &x);
+
+  const int* side_node_ordinals(int sideOrdinal);
 };
 
 // 2D Quad 4 subcontrol volume
@@ -911,6 +926,8 @@ public:
   const int * faceScsIpOnExtrudedElem();
   const int * faceScsIpOnFaceEdges();
   const double * edgeAlignedArea();
+
+  const int* side_node_ordinals(int sideOrdinal);
 };
 
 class QuadrilateralP2Element : public MasterElement
@@ -1065,6 +1082,8 @@ public:
   int opposingFace(
     const int ordinal, const int node);
 
+  const int* side_node_ordinals(int sideOrdinal);
+
 private:
   void set_interior_info();
   void set_boundary_info();
@@ -1188,6 +1207,8 @@ public:
     const double *side_pcoords,
     double *elem_pcoords);
 
+  const int* side_node_ordinals(int sideOrdinal);
+
 };
 
 // 3D Quad 4
@@ -1228,10 +1249,6 @@ public:
     const double *isoParCoord,
     double *shpfc);
 
-  bool within_tol( const double & val, const double & tol );
-  
-  double vector_norm2( const double * vect, int len );
-
   void non_unit_face_normal(
     const double * par_coord,
     const double * elem_nodal_coor,
@@ -1257,6 +1274,17 @@ public:
     double *areav,
     double * error );
 
+  double isInElement(
+    const double *elemNodalCoord,
+    const double *pointCoord,
+    double *isoParCoord);
+
+  void interpolatePoint(
+    const int &nComp,
+    const double *isoParCoord,
+    const double *field,
+    double *result);
+
 private:
   void set_interior_info();
   void eval_shape_functions_at_ips() final;
@@ -1281,6 +1309,13 @@ private:
     const double *par_coord,
     double* shape_fcn
   ) const;
+
+  void non_unit_face_normal(
+    const double *isoParCoord,
+    const double *elemNodalCoord,
+    double *normalVector);
+
+  double parametric_distance(const std::vector<double> &x);
 
   std::vector<double> ipWeight_;
   const int surfaceDimension_;

--- a/include/overset/OversetInfo.h
+++ b/include/overset/OversetInfo.h
@@ -53,6 +53,6 @@ class OversetInfo {
 };
   
 } // end sierra namespace
-} // end naluUnit namespace
+} // end nalu namespace
 
 #endif

--- a/include/overset/OversetManager.h
+++ b/include/overset/OversetManager.h
@@ -1,7 +1,7 @@
 /*------------------------------------------------------------------------*/
 /*  Copyright 2014 Sandia Corporation.                                    */
 /*  This software is released under the license detailed                  */
-/*  in the file, LICENSE, which is located in the top-level NaluUnit      */
+/*  in the file, LICENSE, which is located in the top-level nalu      */
 /*  directory structure                                                   */
 /*------------------------------------------------------------------------*/
 
@@ -180,7 +180,7 @@ public:
 
 };
 
-} // namespace naluUnit
+} // namespace nalu
 } // namespace Sierra
 
 #endif

--- a/include/user_functions/VariableDensityContinuitySrcElemSuppAlg.h
+++ b/include/user_functions/VariableDensityContinuitySrcElemSuppAlg.h
@@ -6,8 +6,8 @@
 /*------------------------------------------------------------------------*/
 
 
-#ifndef MomentumMassBDF2ElemSuppAlg_h
-#define MomentumMassBDF2ElemSuppAlg_h
+#ifndef VariableDensityContinuitySrcElemSuppAlg_h
+#define VariableDensityContinuitySrcElemSuppAlg_h
 
 #include <SupplementalAlgorithm.h>
 #include <FieldTypeDef.h>
@@ -21,14 +21,14 @@ namespace nalu{
 class Realm;
 class MasterElement;
 
-class MomentumMassBDF2ElemSuppAlg : public SupplementalAlgorithm
+class VariableDensityContinuitySrcElemSuppAlg : public SupplementalAlgorithm
 {
 public:
 
-  MomentumMassBDF2ElemSuppAlg(
+  VariableDensityContinuitySrcElemSuppAlg(
     Realm &realm);
 
-  virtual ~MomentumMassBDF2ElemSuppAlg() {}
+  virtual ~VariableDensityContinuitySrcElemSuppAlg() {}
 
   virtual void setup();
 
@@ -45,36 +45,25 @@ public:
   
   const stk::mesh::BulkData *bulkData_;
 
-  VectorFieldType *velocityNm1_;
-  VectorFieldType *velocityN_;
-  VectorFieldType *velocityNp1_;
-  ScalarFieldType *densityNm1_;
-  ScalarFieldType *densityN_;
-  ScalarFieldType *densityNp1_;
-  VectorFieldType *Gjp_;
   VectorFieldType *coordinates_;
 
-  double dt_;
-  double gamma1_;
-  double gamma2_;
-  double gamma3_;
   const int nDim_;
+  const double unot_;
+  const double vnot_;
+  const double wnot_;
+  const double znot_;
+  const double rhoP_;
+  const double rhoS_;
+  const double a_;
+  const double amf_;
+  const double pi_;
+  double projTimeScale_;
   const bool useShifted_;
 
-  // scratch space
-  std::vector<double> uNm1Scv_;
-  std::vector<double> uNScv_;
-  std::vector<double> uNp1Scv_;
-  std::vector<double> GjpScv_;
-
+  // scratch space (at constructor)
+  std::vector<double> scvCoords_;
+  // at elem_resize
   std::vector<double> ws_shape_function_;
-  std::vector<double> ws_uNm1_;
-  std::vector<double> ws_uN_;
-  std::vector<double> ws_uNp1_;
-  std::vector<double> ws_Gjp_;
-  std::vector<double> ws_rhoNm1_;
-  std::vector<double> ws_rhoN_;
-  std::vector<double> ws_rhoNp1_;
   std::vector<double> ws_coordinates_;
   std::vector<double> ws_scv_volume_;
 };

--- a/include/user_functions/VariableDensityMixFracSrcElemSuppAlg.h
+++ b/include/user_functions/VariableDensityMixFracSrcElemSuppAlg.h
@@ -47,7 +47,6 @@ public:
 
   VectorFieldType *coordinates_;
 
-  double dt_;
   const int nDim_;
   const double rhoP_;
   const double rhoS_;
@@ -61,7 +60,6 @@ public:
   const double amf_;
   const double Sc_;  
   const double pi_;
-
   const bool useShifted_;
 
   // scratch space (at constructor)

--- a/include/user_functions/VariableDensityMomentumSrcElemSuppAlg.h
+++ b/include/user_functions/VariableDensityMomentumSrcElemSuppAlg.h
@@ -6,8 +6,8 @@
 /*------------------------------------------------------------------------*/
 
 
-#ifndef ScalarMassBDF2ElemSuppAlg_h
-#define ScalarMassBDF2ElemSuppAlg_h
+#ifndef VariableDensityMomentumSrcElemSuppAlg_h
+#define VariableDensityMomentumSrcElemSuppAlg_h
 
 #include <SupplementalAlgorithm.h>
 #include <FieldTypeDef.h>
@@ -21,15 +21,14 @@ namespace nalu{
 class Realm;
 class MasterElement;
 
-class ScalarMassBDF2ElemSuppAlg : public SupplementalAlgorithm
+class VariableDensityMomentumSrcElemSuppAlg : public SupplementalAlgorithm
 {
 public:
 
-  ScalarMassBDF2ElemSuppAlg(
-    Realm &realm,
-    ScalarFieldType *scalarQ);
+  VariableDensityMomentumSrcElemSuppAlg(
+    Realm &realm);
 
-  virtual ~ScalarMassBDF2ElemSuppAlg() {}
+  virtual ~VariableDensityMomentumSrcElemSuppAlg() {}
 
   virtual void setup();
 
@@ -46,29 +45,32 @@ public:
   
   const stk::mesh::BulkData *bulkData_;
 
-  ScalarFieldType *scalarQNm1_;
-  ScalarFieldType *scalarQN_;
-  ScalarFieldType *scalarQNp1_;
-  ScalarFieldType *densityNm1_;
-  ScalarFieldType *densityN_;
-  ScalarFieldType *densityNp1_;
   VectorFieldType *coordinates_;
 
-  double dt_;
-  double gamma1_;
-  double gamma2_;
-  double gamma3_;
   const int nDim_;
+  const double unot_;
+  const double vnot_;
+  const double wnot_;
+  const double pnot_;
+  const double znot_;
+  const double a_;
+  const double amf_;
+  const double visc_;
+  const double rhoP_;
+  const double rhoS_;
+  const double pi_;
+  const double twoThirds_;
+  double rhoRef_;
+  double gx_;
+  double gy_;
+  double gz_;
   const bool useShifted_;
 
-  // scratch space
+  // scratch space (at constructor)
+  std::vector<double> scvCoords_;
+  std::vector<double> srcXi_;
+  // at elem_resize
   std::vector<double> ws_shape_function_;
-  std::vector<double> ws_qNm1_;
-  std::vector<double> ws_qN_;
-  std::vector<double> ws_qNp1_;
-  std::vector<double> ws_rhoNm1_;
-  std::vector<double> ws_rhoN_;
-  std::vector<double> ws_rhoNp1_;
   std::vector<double> ws_coordinates_;
   std::vector<double> ws_scv_volume_;
 };

--- a/src/ActuatorLine.C
+++ b/src/ActuatorLine.C
@@ -1,0 +1,1031 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include <ActuatorLine.h>
+#include <FieldTypeDef.h>
+#include <NaluParsing.h>
+#include <NaluEnv.h>
+#include <Realm.h>
+#include <Simulation.h>
+
+// master elements
+#include <master_element/MasterElement.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/FieldParallel.hpp>
+#include <stk_mesh/base/GetBuckets.hpp>
+#include <stk_mesh/base/Selector.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Part.hpp>
+
+// stk_util
+#include <stk_util/parallel/ParallelReduce.hpp>
+
+// stk_search
+#include <stk_search/CoarseSearch.hpp>
+#include <stk_search/IdentProc.hpp>
+
+// basic c++
+#include <vector>
+#include <map>
+#include <string>
+#include <stdexcept>
+#include <cmath>
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// ActuatorLineInfo - holds all points in the tower specification
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+ActuatorLineInfo::ActuatorLineInfo() 
+  : processorId_(0),
+    numPoints_(1),
+    turbineName_("machine_one"),
+    radius_(0),
+    omega_(0.0),
+    twoSigSq_(0.0)
+{
+  // nothing to do
+}
+
+//--------------------------------------------------------------------------
+//-------- destructor ------------------------------------------------------
+//--------------------------------------------------------------------------
+ActuatorLineInfo::~ActuatorLineInfo()
+{
+  // nothing to do
+}
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// ActuatorLinePointInfo - holds individual points information
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+ActuatorLinePointInfo::ActuatorLinePointInfo( 
+  size_t localId, 
+  Point centroidCoords, 
+  double radius, 
+  double omega,
+  double twoSigSq) 
+  : localId_(localId),
+    centroidCoords_(centroidCoords),
+    radius_(radius),
+    omega_(omega),
+    twoSigSq_(twoSigSq),
+    bestX_(1.0e16),
+    bestElem_(stk::mesh::Entity())
+{
+  // nothing to do
+}
+
+//--------------------------------------------------------------------------
+//-------- destructor ------------------------------------------------------
+//--------------------------------------------------------------------------
+ActuatorLinePointInfo::~ActuatorLinePointInfo()
+{
+  // nothing to do
+}
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// ActuatorLine - assemble source term for subgrin turbine; WIP
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+ActuatorLine::ActuatorLine(
+  Realm &realm,
+  const YAML::Node &node)
+  : realm_(realm),
+    searchMethod_(stk::search::BOOST_RTREE),
+    actuatorLineGhosting_(NULL),
+    needToGhostCount_(0),
+    localPointId_(0),
+    actuatorLineMotion_(false),
+    pi_(acos(-1.0))
+{
+  // load the data
+  load(node);
+
+  /*
+    current WIP prototype
+    Design concepts:
+     1) First and foremost, elements are ghosted to the owning point rank. This 
+        probably should be changed since the number of elements might be larger
+        than the number of points. Therefore, ghosting points to elements is probably
+        easier. This will remove the parallel sum contributions from ghosted elements.
+        time will tell..
+
+     2) There can be many specifications with the number of points and omaga processed.
+
+     3) in the end, we fill the map of ActuatorLinePointInfo objects and iterate this guy
+        to assemble source terms
+
+     4) at present, fake source terms on simple gaussian weighting
+
+    actuator_line:
+      search_method: stk_octree
+      search_target_part: block_1
+
+      specifications:
+
+        - name: machine_one 
+          radius: 2.0
+          omega: 1.0
+          gaussian_decay_radius: 1.5
+          gaussian_decay_target: 0.01
+          coodinates: [0.0, 0.0, 0.0]
+  */
+}
+
+//--------------------------------------------------------------------------
+//-------- destructor ------------------------------------------------------
+//--------------------------------------------------------------------------
+ActuatorLine::~ActuatorLine()
+{
+  // delete data probes specifications vector
+  for ( size_t k = 0; k < actuatorLineInfo_.size(); ++k )
+    delete actuatorLineInfo_[k];
+}
+
+//--------------------------------------------------------------------------
+//-------- compute_point_drag ----------------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::compute_point_drag( 
+  const int &nDim,
+  const double &pointRadius, 
+  const double *pointGasVelocity,
+  const double &pointGasViscosity,
+  const double &pointGasDensity,
+  double *pointDrag,
+  double &pointDragLHS)
+{
+  // HACK... assume point velocity is zero
+  double pointVelocity = 0.0;
+  double vRelMag = 0.0;
+  for ( int j = 0; j < nDim; ++j )
+    vRelMag += (pointVelocity - pointGasVelocity[j] )*(pointVelocity - pointGasVelocity[j]);
+  vRelMag = std::sqrt(vRelMag);
+
+  // Reynolds number and friction factors
+  double ReP = 2.0*pointGasDensity*pointRadius*vRelMag/pointGasViscosity;
+  double CubeRtReP = (ReP < 1000.) ? std::cbrt(ReP) : 0.0;
+  double fD = (ReP < 1000.0) ? (1.0 + CubeRtReP*CubeRtReP/6.0) : (0.424/24.0 * ReP);
+  double coef = 6.0*pi_*pointGasViscosity*pointRadius;
+
+  // this is from the fluids perspective, not the psuego particle
+  pointDragLHS = 2.0*coef*fD;
+  for ( int j = 0; j < nDim; ++j )
+    pointDrag[j] = coef*fD*(pointVelocity - pointGasVelocity[j]);
+}
+
+//--------------------------------------------------------------------------
+//-------- compute_elem_drag_given_radius ----------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::compute_elem_drag_given_radius( 
+  const int &nDim,
+  const double &radius, 
+  const double &twoSigSq,
+  const double *pointDrag,
+  double *elemDrag)
+{
+  // gaussian weight based on radius
+  const double gaussWeight = std::exp(-radius*radius/twoSigSq);
+  for ( int j = 0; j < nDim; ++j )
+    elemDrag[j] = pointDrag[j]*gaussWeight;
+}
+
+//--------------------------------------------------------------------------
+//-------- load ------------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::load(
+  const YAML::Node & y_node)
+{
+  // check for any data probes
+  const YAML::Node *y_actuatorLine = y_node.FindValue("actuator_line");
+  if (y_actuatorLine) {
+    NaluEnv::self().naluOutputP0() << "ActuatorLine::load" << std::endl;
+
+    // search specifications
+    std::string searchMethodName = "na";
+    get_if_present(*y_actuatorLine, "search_method", searchMethodName, searchMethodName);
+    
+    // determine search method for this pair
+    if ( searchMethodName == "boost_rtree" )
+      searchMethod_ = stk::search::BOOST_RTREE;
+    else if ( searchMethodName == "stk_octree" )
+      searchMethod_ = stk::search::OCTREE;
+    else
+      NaluEnv::self().naluOutputP0() << "ActuatorLine::search method not declared; will use BOOST_RTREE" << std::endl;
+
+    // extract the set of from target names; each spec is homogeneous in this respect
+    const YAML::Node &searchTargets = (*y_actuatorLine)["search_target_part"];
+    if (searchTargets.Type() == YAML::NodeType::Scalar) {
+      searchTargetNames_.resize(1);
+      searchTargets >> searchTargetNames_[0];
+    }
+    else {
+      searchTargetNames_.resize(searchTargets.size());
+      for (size_t i=0; i < searchTargets.size(); ++i) {
+        searchTargets[i] >> searchTargetNames_[i];
+      }
+    }
+    
+    const YAML::Node *y_specs = expect_sequence(*y_actuatorLine, "specifications", false);
+    if (y_specs) {
+
+      // save off number of towers
+      const int numTowers = y_specs->size();
+
+      // deal with processors... Distribute each tower over subsequent procs
+      const int numProcs = NaluEnv::self().parallel_size();
+      const int divProcTower = std::max(numProcs/numTowers, numProcs);
+
+      // each specification can have multiple machines
+      for (size_t ispec = 0; ispec < y_specs->size(); ++ispec) {
+        const YAML::Node &y_spec = (*y_specs)[ispec];
+        
+        ActuatorLineInfo *actuatorLineInfo = new ActuatorLineInfo();
+        actuatorLineInfo_.push_back(actuatorLineInfo);
+        
+        // name
+        const YAML::Node *theName = y_spec.FindValue("turbine_name");
+        if ( theName )
+          *theName >> actuatorLineInfo->turbineName_;
+        else
+          throw std::runtime_error("ActuatorLine: no name provided");
+        
+        // processor id; distribute los equally over the number of processors
+        actuatorLineInfo->processorId_ = divProcTower > 0 ? ispec % divProcTower : 0;
+
+        // number of points
+        get_if_present(y_spec, "number_of_points", actuatorLineInfo->numPoints_, actuatorLineInfo->numPoints_);
+        if ( actuatorLineInfo->numPoints_ > 1 )
+          throw std::runtime_error("ActuatorLine: number of points must be unity");
+
+        // radius and omega
+        get_if_present(y_spec, "radius", actuatorLineInfo->radius_, actuatorLineInfo->radius_);
+        get_if_present(y_spec, "omega", actuatorLineInfo->omega_, actuatorLineInfo->omega_);
+        if ( actuatorLineInfo->omega_ != 0.0 )
+          throw std::runtime_error("ActuatorLine: not ready for omega not equal to zero");
+        
+        // finally, the gaussian props
+        double gaussDecayTarget = 0.01;
+        double gaussDecayRadius = 1.5;
+        get_if_present(y_spec, "gaussian_decay_radius", gaussDecayRadius, gaussDecayRadius);
+        get_if_present(y_spec, "gaussian_decay_target", gaussDecayTarget, gaussDecayTarget);
+        actuatorLineInfo->twoSigSq_ = -gaussDecayRadius*gaussDecayRadius/std::log(gaussDecayTarget);
+        
+        // coordinates of this point
+        const YAML::Node *coord = y_spec.FindValue("coordinates");
+        if ( coord )
+          *coord >> actuatorLineInfo->coordinates_;
+        else
+          throw std::runtime_error("ActuatorLine: lacking coordinates");
+      }
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- setup -----------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::setup()
+{
+  // objective: declare the part, register coordinates; must be before populate_mesh()
+}
+
+//--------------------------------------------------------------------------
+//-------- initialize ------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::initialize()
+{
+  stk::mesh::BulkData & bulkData = realm_.bulk_data();
+  stk::mesh::MetaData & metaData = realm_.meta_data();
+ 
+  const int nDim = metaData.spatial_dimension();
+
+  // initialize need to ghost and elems to ghost
+  needToGhostCount_ = 0;
+  elemsToGhost_.clear();
+
+  // clear actuatorLinePointInfoMap_
+  std::map<size_t, ActuatorLinePointInfo *>::iterator iterPoint;
+  for( iterPoint=actuatorLinePointInfoMap_.begin(); iterPoint!=actuatorLinePointInfoMap_.end(); ++iterPoint )
+    delete (*iterPoint).second;
+  actuatorLinePointInfoMap_.clear();
+  
+  bulkData.modification_begin();
+  
+  if ( actuatorLineGhosting_ == NULL) {
+    // create new ghosting
+    std::string theGhostName = "nalu_actuator_line_ghosting";
+    actuatorLineGhosting_ = &bulkData.create_ghosting( theGhostName );
+  }
+  else {
+    bulkData.destroy_ghosting(*actuatorLineGhosting_);
+  }
+  
+  bulkData.modification_end();
+  
+  // clear some of the search info
+  boundingSphereVec_.clear();
+  boundingElementBoxVec_.clear();
+  searchKeyPair_.clear();
+
+  // set all of the candidate elements in the search target names
+  populate_candidate_elements();
+  
+  // create the ActuatorLinePointInfo
+  create_actuator_line_point_info_map();
+
+  // coarse search
+  determine_elems_to_ghost();
+
+  // manage ghosting
+  manage_ghosting();
+  
+  // complete filling in the set of elements connected to the centroid
+  complete_search();
+}
+
+//--------------------------------------------------------------------------
+//-------- execute ---------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::execute()
+{
+  // do we have mesh motion?
+  if ( actuatorLineMotion_ )
+    initialize();
+
+  // meta/bulk data and nDim
+  stk::mesh::MetaData & metaData = realm_.meta_data();
+  stk::mesh::BulkData & bulkData = realm_.bulk_data();
+  const int nDim = metaData.spatial_dimension();
+
+  // extract fields
+  VectorFieldType *coordinates 
+    = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  VectorFieldType *velocity = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  VectorFieldType *actuator_line_source 
+    = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "actuator_line_source");
+  ScalarFieldType *actuator_line_source_lhs
+    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "actuator_line_source_lhs");
+  ScalarFieldType *density
+    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density"); 
+  // deal with proper viscosity
+  const std::string viscName = realm_.is_turbulent() ? "effective_viscosity" : "viscosity";
+  ScalarFieldType *viscosity
+    = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, viscName); 
+
+  // fixed size scratch
+  std::vector<double> ws_pointGasVelocity(nDim);
+  std::vector<double> ws_elemCentroid(nDim);
+  std::vector<double> ws_pointDrag(nDim);
+  std::vector<double> ws_elemDrag(nDim);
+  double ws_pointGasDensity;
+  double ws_pointGasViscosity;
+  double ws_pointDragLHS;
+  
+  // zero out source term; do this manually since there are custom ghosted entities
+  stk::mesh::Selector s_nodes = stk::mesh::selectField(*actuator_line_source);
+  stk::mesh::BucketVector const& node_buckets =
+    realm_.get_buckets( stk::topology::NODE_RANK, s_nodes );
+  for ( stk::mesh::BucketVector::const_iterator ib = node_buckets.begin() ;
+        ib != node_buckets.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+    const stk::mesh::Bucket::size_type length   = b.size();
+    double * actSrc = stk::mesh::field_data(*actuator_line_source, b);
+    double * actSrcLhs = stk::mesh::field_data(*actuator_line_source_lhs, b);
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+      actSrcLhs[k] = 0.0;
+      const int offSet = k*nDim;
+      for ( int j = 0; j < nDim; ++j ) {
+        actSrc[offSet+j] = 0.0;
+      }
+    }
+  }
+
+  // parallel communicate data to the ghosted elements; again can communicate points to element ranks
+  if ( NULL != actuatorLineGhosting_ ) {
+    std::vector< const stk::mesh::FieldBase *> ghostFieldVec;
+    // fields that are needed
+    ghostFieldVec.push_back(coordinates);
+    ghostFieldVec.push_back(velocity);
+    ghostFieldVec.push_back(viscosity);
+    stk::mesh::communicate_field_data(*actuatorLineGhosting_, ghostFieldVec);
+  }
+
+  // loop over map and assemble source terms
+  std::map<size_t, ActuatorLinePointInfo *>::iterator iterPoint;
+  for (iterPoint  = actuatorLinePointInfoMap_.begin();
+       iterPoint != actuatorLinePointInfoMap_.end();
+       ++iterPoint) {
+
+    // actuator line info object of interest
+    ActuatorLinePointInfo * infoObject = (*iterPoint).second;
+
+    //==========================================================================
+    // extract the best element; compute drag given this velocity, property, etc
+    // this point drag value will be used by all other elements below
+    //==========================================================================
+    stk::mesh::Entity bestElem = infoObject->bestElem_;
+    int nodesPerElement = bulkData.num_nodes(bestElem);
+    
+    // resize some work vectors
+    resize_std_vector(nDim, ws_coordinates_, bestElem, bulkData);
+    resize_std_vector(nDim, ws_velocity_, bestElem, bulkData);
+    resize_std_vector(1, ws_viscosity_, bestElem, bulkData);
+    resize_std_vector(1, ws_density_, bestElem, bulkData);
+
+    // gather nodal data to element nodes; both vector and scalar; coords are used in determinant calc
+    gather_field(nDim, &ws_coordinates_[0], *coordinates, bulkData.begin_nodes(bestElem), 
+                 nodesPerElement);
+    gather_field_for_interp(nDim, &ws_velocity_[0], *velocity, bulkData.begin_nodes(bestElem), 
+                            nodesPerElement);
+    gather_field_for_interp(1, &ws_viscosity_[0], *viscosity, bulkData.begin_nodes(bestElem), 
+                            nodesPerElement);
+    gather_field_for_interp(1, &ws_density_[0], *density, bulkData.begin_nodes(bestElem), 
+                            nodesPerElement);
+
+    // compute volume
+    double elemVolume = compute_volume(nDim, bestElem, bulkData);
+
+    // interpolate velocity
+    interpolate_field(nDim, bestElem, bulkData, &(infoObject->isoParCoords_[0]), 
+                      &ws_velocity_[0], &ws_pointGasVelocity[0]);
+    
+    // interpolate viscosity
+    interpolate_field(1, bestElem, bulkData, &(infoObject->isoParCoords_[0]), 
+                      &ws_viscosity_[0], &ws_pointGasViscosity);
+
+    // interpolate density
+    interpolate_field(1, bestElem, bulkData, &(infoObject->isoParCoords_[0]), 
+                      &ws_density_[0], &ws_pointGasDensity);
+    
+    // point drag calculation
+    compute_point_drag(nDim, infoObject->radius_, &ws_pointGasVelocity[0], ws_pointGasViscosity, 
+                       ws_pointGasDensity, &ws_pointDrag[0], ws_pointDragLHS);
+        
+    // assemble nodal quantity; radius should be zero, so we can apply fill point drag
+    assemble_source_to_nodes(nDim, bestElem, bulkData, elemVolume, &ws_pointDrag[0], ws_pointDragLHS, 
+                             *actuator_line_source, *actuator_line_source_lhs, 1.0);
+
+    // get the vector of elements
+    std::vector<stk::mesh::Entity> elementVec = infoObject->elementVec_;
+
+    // iterate them and apply source term; gather coords
+    for ( size_t k = 0; k < elementVec.size(); ++k ) {
+
+      stk::mesh::Entity elem = elementVec[k];
+
+      nodesPerElement = bulkData.num_nodes(elem);
+    
+      // resize some work vectors
+      resize_std_vector(nDim, ws_coordinates_, elem, bulkData);
+
+      // gather coordinates
+      gather_field(nDim, &ws_coordinates_[0], *coordinates, bulkData.begin_nodes(elem), 
+                   nodesPerElement);
+
+      // compute volume
+      double elemVolume = compute_volume(nDim, elem, bulkData);
+
+      // determine element centroid
+      compute_elem_centroid(nDim, &ws_elemCentroid[0], nodesPerElement);
+
+      // compute radius
+      const double radius = compute_radius(nDim, &ws_elemCentroid[0], &(infoObject->centroidCoords_[0]));
+    
+      // get drag at this element centroid with proper Gaussian weighting
+      compute_elem_drag_given_radius(nDim, radius, infoObject->twoSigSq_, &ws_pointDrag[0], &ws_elemDrag[0]);
+    
+      // assemble nodal quantity; no LHS contribution here...
+      assemble_source_to_nodes(nDim, elem, bulkData, elemVolume, &ws_elemDrag[0], ws_pointDragLHS, 
+                               *actuator_line_source, *actuator_line_source_lhs, 0.0);
+    } 
+  }
+
+  // parallel assemble (contributions from ghosted and locally owned)
+  const std::vector<const stk::mesh::FieldBase*> sumFieldVec(1, actuator_line_source);
+  stk::mesh::parallel_sum_including_ghosts(bulkData, sumFieldVec);
+}
+
+//--------------------------------------------------------------------------
+//-------- populate_candidate_elements -------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::populate_candidate_elements() 
+{
+  stk::mesh::MetaData & metaData = realm_.meta_data();
+  stk::mesh::BulkData & bulkData = realm_.bulk_data();
+
+  const int nDim = metaData.spatial_dimension();
+
+  // fields
+  VectorFieldType *coordinates = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+
+  // point data structures
+  Point minCorner, maxCorner;
+
+  // extract part
+  stk::mesh::PartVector searchParts;
+  for ( size_t k = 0; k < searchTargetNames_.size(); ++k ) {
+    stk::mesh::Part *thePart = metaData.get_part(searchTargetNames_[k]);
+    if ( NULL != thePart )
+      searchParts.push_back(thePart);
+    else
+      throw std::runtime_error("ActuatorLine: Part is null" + searchTargetNames_[k]);     
+  }
+
+  // selector and bucket loop
+  stk::mesh::Selector s_locally_owned = metaData.locally_owned_part()
+    &stk::mesh::selectUnion(searchParts);
+  
+  stk::mesh::BucketVector const& elem_buckets =
+    realm_.get_buckets( stk::topology::ELEMENT_RANK, s_locally_owned );
+
+  for ( stk::mesh::BucketVector::const_iterator ib = elem_buckets.begin();
+        ib != elem_buckets.end() ; ++ib ) {
+    
+    stk::mesh::Bucket & b = **ib;
+
+    const stk::mesh::Bucket::size_type length   = b.size();
+
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+
+      // get element
+      stk::mesh::Entity elem = b[k];
+
+      // initialize max and min
+      for (int j = 0; j < nDim; ++j ) {
+        minCorner[j] = +1.0e16;
+        maxCorner[j] = -1.0e16;
+      }
+
+      // extract elem_node_relations
+      stk::mesh::Entity const* elem_node_rels = bulkData.begin_nodes(elem);
+      const int num_nodes = bulkData.num_nodes(elem);
+
+      for ( int ni = 0; ni < num_nodes; ++ni ) {
+        stk::mesh::Entity node = elem_node_rels[ni];
+        
+        // pointers to real data
+        const double * coords = stk::mesh::field_data(*coordinates, node );
+        
+        // check max/min
+        for ( int j = 0; j < nDim; ++j ) {
+          minCorner[j] = std::min(minCorner[j], coords[j]);
+          maxCorner[j] = std::max(maxCorner[j], coords[j]);
+        }
+      }
+      
+      // setup ident
+      stk::search::IdentProc<uint64_t,int> theIdent(bulkData.identifier(elem), NaluEnv::self().parallel_rank());
+      
+      // create the bounding point box and push back
+      boundingElementBox theBox(Box(minCorner,maxCorner), theIdent);
+      boundingElementBoxVec_.push_back(theBox);
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- determine_elems_to_ghost ----------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::determine_elems_to_ghost()
+{
+  stk::mesh::BulkData & bulkData = realm_.bulk_data();
+
+  stk::search::coarse_search(boundingSphereVec_, boundingElementBoxVec_, searchMethod_, 
+                             NaluEnv::self().parallel_comm(), searchKeyPair_);
+
+  // lowest effort is to ghost elements to the owning rank of the point; can just as easily do the opposite
+  std::vector<std::pair<boundingSphere::second_type, boundingElementBox::second_type> >::const_iterator ii;
+  for( ii=searchKeyPair_.begin(); ii!=searchKeyPair_.end(); ++ii ) {
+
+    const uint64_t theBox = ii->second.id();
+    unsigned theRank = NaluEnv::self().parallel_rank();
+    const unsigned pt_proc = ii->first.proc();
+    const unsigned box_proc = ii->second.proc();
+    if ( (box_proc == theRank) && (pt_proc != theRank) ) {
+
+      // Send box to pt proc
+      
+      // find the element
+      stk::mesh::Entity theElemMeshObj = bulkData.get_entity(stk::topology::ELEMENT_RANK, theBox);
+      if ( !(bulkData.is_valid(theElemMeshObj)) )
+        throw std::runtime_error("no valid entry for element");
+
+      // new element to ghost counter
+      needToGhostCount_++;
+
+      // deal with elements to push back to be ghosted
+      stk::mesh::EntityProc theElemPair(theElemMeshObj, pt_proc);
+      elemsToGhost_.push_back(theElemPair);
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- create_actuator_line_point_info_map -----------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::create_actuator_line_point_info_map() {
+  stk::mesh::MetaData & metaData = realm_.meta_data(); 
+  const int nDim = metaData.spatial_dimension();
+
+  for ( size_t k = 0; k < actuatorLineInfo_.size(); ++k ) {
+    
+    const ActuatorLineInfo *actuatorLineInfo = actuatorLineInfo_[k];
+    
+    int processorId = actuatorLineInfo->processorId_;
+    if ( processorId == NaluEnv::self().parallel_rank() ) {
+      
+      // define a point that will hold the centroid
+      Point centroidCoords;
+      
+      // loop over all points
+      for ( int j = 0; j < actuatorLineInfo->numPoints_; ++j ) {
+        // extract current localPointId; increment for next one up...
+        size_t localPointId = localPointId_++;
+        stk::search::IdentProc<uint64_t,int> theIdent(localPointId, NaluEnv::self().parallel_rank());
+        
+        // extract model coordinates
+        centroidCoords[0] = actuatorLineInfo->coordinates_.x_;
+        centroidCoords[1] = actuatorLineInfo->coordinates_.y_;
+        if ( nDim > 2 )
+          centroidCoords[2] = actuatorLineInfo->coordinates_.z_;
+        
+        // move the coordinates; set the velocity... may be better on the lineInfo object
+        set_current_coordinates(actuatorLineInfo->omega_);
+        set_current_velocity(actuatorLineInfo->omega_);
+
+        // create the bounding point sphere and push back
+        boundingSphere theSphere( Sphere(centroidCoords, actuatorLineInfo->radius_), theIdent);
+        boundingSphereVec_.push_back(theSphere);
+        
+        // create the point info and push back to map
+        ActuatorLinePointInfo *actuatorLinePointInfo 
+          = new ActuatorLinePointInfo(localPointId, centroidCoords, 
+                                      actuatorLineInfo->radius_, actuatorLineInfo->omega_, 
+                                      actuatorLineInfo->twoSigSq_);
+        actuatorLinePointInfoMap_[localPointId] = actuatorLinePointInfo;
+      }
+    }
+  }  
+}
+
+//--------------------------------------------------------------------------
+//-------- set_current_coordinates -----------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::set_current_coordinates() 
+{
+  // to do
+}
+
+//--------------------------------------------------------------------------
+//-------- set_current_coordinates -----------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::set_current_coordinates( const double &/*omega*/) 
+{
+  // to do
+}
+
+//--------------------------------------------------------------------------
+//-------- set_current_velocity --------------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::set_current_velocity( const double &/*omega*/) 
+{
+  // to do
+}
+
+//--------------------------------------------------------------------------
+//-------- manage_ghosting -------------------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::manage_ghosting() 
+{
+  stk::mesh::BulkData & bulkData = realm_.bulk_data();
+  
+  // check for ghosting need
+  uint64_t g_needToGhostCount = 0;
+  stk::all_reduce_sum(NaluEnv::self().parallel_comm(), &needToGhostCount_, &g_needToGhostCount, 1);
+  if (g_needToGhostCount > 0) {
+    NaluEnv::self().naluOutputP0() << "ActuatorLine alg will ghost a number of entities: "
+                                   << g_needToGhostCount  << std::endl;
+    bulkData.modification_begin();
+    bulkData.change_ghosting( *actuatorLineGhosting_, elemsToGhost_);
+    bulkData.modification_end();
+  }
+  else {
+    NaluEnv::self().naluOutputP0() << "ActuatorLine alg will NOT ghost entities: " << std::endl;
+  }
+}
+  
+//--------------------------------------------------------------------------
+//-------- complete_search -------------------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::complete_search()
+{
+  stk::mesh::MetaData & metaData = realm_.meta_data();
+  stk::mesh::BulkData & bulkData = realm_.bulk_data();
+  const int nDim = metaData.spatial_dimension();
+
+  // extract fields
+  VectorFieldType *coordinates 
+    = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+ 
+  // now proceed with the standard search
+  std::vector<std::pair<boundingSphere::second_type, boundingElementBox::second_type> >::const_iterator ii;
+  for( ii=searchKeyPair_.begin(); ii!=searchKeyPair_.end(); ++ii ) {
+
+    const uint64_t thePt = ii->first.id();
+    const uint64_t theBox = ii->second.id();
+    const unsigned theRank = NaluEnv::self().parallel_rank();
+    const unsigned pt_proc = ii->first.proc();
+
+    // check if I own the point...
+    if ( theRank == pt_proc ) {
+
+      // yes, I own the point... 
+
+      // proceed as required; all elements should have already been ghosted via the coarse search
+      stk::mesh::Entity elem = bulkData.get_entity(stk::topology::ELEMENT_RANK, theBox);
+      if ( !(bulkData.is_valid(elem)) )
+        throw std::runtime_error("no valid entry for element");
+
+      // find the point data structure
+      std::map<size_t, ActuatorLinePointInfo *>::iterator iterPoint;
+      iterPoint=actuatorLinePointInfoMap_.find(thePt);
+      if ( iterPoint == actuatorLinePointInfoMap_.end() )
+        throw std::runtime_error("no valid entry for actuatorLinePointInfoMap_");
+      
+      // extract the point object and push back the element to either the best 
+      // candidate or the standard vector of elements
+      ActuatorLinePointInfo *actuatorLinePointInfo = iterPoint->second;
+
+      // extract topo and master element for this topo
+      const stk::mesh::Bucket &theBucket = bulkData.bucket(elem);
+      const stk::topology &elemTopo = theBucket.topology();
+      MasterElement *meSCS = realm_.get_surface_master_element(elemTopo);
+      const int nodesPerElement = meSCS->nodesPerElement_;
+
+      // gather elemental coords
+      std::vector<double> elementCoords(nDim*nodesPerElement);
+      gather_field(nDim, &elementCoords[0], *coordinates, bulkData.begin_nodes(elem), 
+                   nodesPerElement);
+
+      
+      // find isoparametric points
+      std::vector<double> isoParCoords(nDim);
+      const double nearestDistance = meSCS->isInElement(&elementCoords[0],
+                                                        &(actuatorLinePointInfo->centroidCoords_[0]),
+                                                        &(isoParCoords[0]));
+      
+      // save off best element and its isoparametric coordinates for this point
+      if ( nearestDistance < actuatorLinePointInfo->bestX_ ) { 
+        actuatorLinePointInfo->bestX_ = nearestDistance;    
+        actuatorLinePointInfo->isoParCoords_ = isoParCoords;
+        if ( stk::mesh::Entity() == actuatorLinePointInfo->bestElem_ ) {
+          actuatorLinePointInfo->bestElem_ = elem;
+        }
+        else { 
+          // swap the current best element
+          actuatorLinePointInfo->elementVec_.push_back(actuatorLinePointInfo->bestElem_);
+          actuatorLinePointInfo->bestElem_ = elem;
+        }
+      }   
+      else {
+        // regular element
+        actuatorLinePointInfo->elementVec_.push_back(elem);
+      }
+    }
+    else {
+      // not this proc's issue
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- resize_std_vector -----------------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::resize_std_vector( 
+  const int &sizeOfField,
+  std::vector<double> &theVector,   
+  stk::mesh::Entity elem, 
+  const stk::mesh::BulkData & bulkData)
+{
+  const stk::topology &elemTopo = bulkData.bucket(elem).topology();
+  MasterElement *meSCS = realm_.get_surface_master_element(elemTopo);
+  const int nodesPerElement = meSCS->nodesPerElement_;
+  theVector.resize(nodesPerElement*sizeOfField);
+}
+
+//--------------------------------------------------------------------------
+//-------- gather_field ----------------------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::gather_field(
+  const int &sizeOfField,
+  double *fieldToFill, 
+  const stk::mesh::FieldBase &stkField,
+  stk::mesh::Entity const* elem_node_rels, 
+  const int &nodesPerElement) 
+{
+  for ( int ni = 0; ni < nodesPerElement; ++ni ) { 
+    stk::mesh::Entity node = elem_node_rels[ni];     
+    const double * theField = (double*)stk::mesh::field_data(stkField, node );
+    for ( int j = 0; j < sizeOfField; ++j ) { 
+      const int offSet = ni*sizeOfField+j;
+      fieldToFill[offSet] = theField[j];
+    }   
+  }   
+}
+
+//--------------------------------------------------------------------------
+//-------- gather_field_for_interp -----------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::gather_field_for_interp(
+  const int &sizeOfField,
+  double *fieldToFill, 
+  const stk::mesh::FieldBase &stkField,
+  stk::mesh::Entity const* elem_node_rels, 
+  const int &nodesPerElement) 
+{
+  for ( int ni = 0; ni < nodesPerElement; ++ni ) { 
+    stk::mesh::Entity node = elem_node_rels[ni];     
+    const double * theField = (double*)stk::mesh::field_data(stkField, node );
+    for ( int j = 0; j < sizeOfField; ++j ) { 
+      const int offSet = j*nodesPerElement + ni; 
+      fieldToFill[offSet] = theField[j];
+    }   
+  }   
+}
+
+//--------------------------------------------------------------------------
+//-------- compute_volume --------------------------------------------------
+//--------------------------------------------------------------------------
+double
+ActuatorLine::compute_volume(
+  const int &nDim,
+  stk::mesh::Entity elem, 
+  const stk::mesh::BulkData & bulkData) 
+{
+  // extract master element from the bucket in which the element resides
+  const stk::topology &elemTopo = bulkData.bucket(elem).topology();
+  MasterElement *meSCV = realm_.get_volume_master_element(elemTopo);
+  int nodesPerElement = meSCV->nodesPerElement_;
+  const int numScvIp = meSCV->numIntPoints_;
+
+  // compute scv for this element
+  ws_scv_volume_.resize(numScvIp);
+  double scv_error = 0.0;
+  meSCV->determinant(1, &ws_coordinates_[0], &ws_scv_volume_[0], &scv_error);
+
+  double elemVolume = 0.0;
+  for ( int ip = 0; ip < numScvIp; ++ip ) {
+    elemVolume += ws_scv_volume_[ip];
+  }
+  return elemVolume;
+}
+
+//--------------------------------------------------------------------------
+//-------- interpolate_field -----------------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::interpolate_field(
+  const int &sizeOfField,
+  stk::mesh::Entity elem, 
+  const stk::mesh::BulkData & bulkData,
+  double *isoParCoords,
+  const double *fieldAtNodes,
+  double *pointField) 
+{
+  // extract master element from the bucket in which the element resides
+  const stk::topology &elemTopo = bulkData.bucket(elem).topology();
+  MasterElement *meSCS = realm_.get_surface_master_element(elemTopo);
+  
+  // interpolate velocity to this best point
+  meSCS->interpolatePoint(
+    sizeOfField,
+    isoParCoords,
+    fieldAtNodes,
+    pointField); 
+}
+
+//--------------------------------------------------------------------------
+//-------- compute_elem_centroid -------------------------------------------
+//--------------------------------------------------------------------------
+void
+ActuatorLine::compute_elem_centroid(
+  const int &nDim,
+  double *elemCentroid,
+  const int & nodesPerElement) 
+{
+  // zero
+  for ( int j = 0; j < nDim; ++j )
+    elemCentroid[j] = 0.0;
+  
+  // assemble
+  for ( int ni = 0; ni < nodesPerElement; ++ni ) {
+    for ( int j=0; j < nDim; ++j ) {
+      elemCentroid[j] += ws_coordinates_[ni*nDim+j]/nodesPerElement;
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- compute_radius ------------------------------------------------
+//--------------------------------------------------------------------------
+double
+ActuatorLine::compute_radius(
+  const int &nDim,
+  const double *elemCentroid,
+  const double *pointCentroid) 
+{ 
+  double radius = 0.0;
+  for ( int j = 0; j < nDim; ++j )
+    radius += std::pow(elemCentroid[j] - pointCentroid[j], 2);
+  radius = std::sqrt(radius);
+  return radius;
+}
+
+//--------------------------------------------------------------------------
+//-------- assemble_source_to_nodes ----------------------------------------
+//-------------------------------------------------------------------------
+void
+ActuatorLine::assemble_source_to_nodes(
+  const int &nDim,
+  stk::mesh::Entity elem, 
+  const stk::mesh::BulkData & bulkData,
+  const double &elemVolume,
+  const double *drag,
+  const double &dragLHS,
+  stk::mesh::FieldBase &actuator_line_source,
+  stk::mesh::FieldBase &actuator_line_source_lhs,
+  const double &lhsFac) 
+{
+  // extract master element from the bucket in which the element resides
+  const stk::topology &elemTopo = bulkData.bucket(elem).topology();
+  MasterElement *meSCV = realm_.get_volume_master_element(elemTopo);
+  int nodesPerElement = meSCV->nodesPerElement_;
+  const int numScvIp = meSCV->numIntPoints_;
+
+  // extract elem_node_relations
+  stk::mesh::Entity const* elem_node_rels = bulkData.begin_nodes(elem);
+
+  // assemble to nodes
+  const int *ipNodeMap = meSCV->ipNodeMap();
+  for ( int ip = 0; ip < numScvIp; ++ip ) {
+      
+    // nearest node to ip
+    const int nearestNode = ipNodeMap[ip];
+    
+    // extract node and pointer to source term
+    stk::mesh::Entity node = elem_node_rels[nearestNode];
+    double * sourceTerm = (double*)stk::mesh::field_data(actuator_line_source, node );
+    double * sourceTermLHS = (double*)stk::mesh::field_data(actuator_line_source_lhs, node );
+    
+    // nodal weight based on volume weight
+    const double nodalWeight = ws_scv_volume_[ip]/elemVolume;
+    *sourceTermLHS += nodalWeight*dragLHS*lhsFac;
+    for ( int j=0; j < nDim; ++j ) {
+      sourceTerm[j] += nodalWeight*drag[j];
+    }
+  } 
+}
+  
+} // namespace nalu
+} // namespace Sierra

--- a/src/AssembleContinuityEdgeOpenSolverAlgorithm.C
+++ b/src/AssembleContinuityEdgeOpenSolverAlgorithm.C
@@ -139,7 +139,7 @@ AssembleContinuityEdgeOpenSolverAlgorithm::execute()
 
     // size some things that are useful
     const int num_face_nodes = b.topology().num_nodes();
-    std::vector<int> face_node_ordinals(num_face_nodes);
+    
 
     const stk::mesh::Bucket::size_type length   = b.size();
 
@@ -161,7 +161,7 @@ AssembleContinuityEdgeOpenSolverAlgorithm::execute()
       // get element; its face ordinal number and populate face_node_ordinals
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = b.begin_element_ordinals(k)[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
+      const int *face_node_ordinals = meSCS->side_node_ordinals(face_ordinal);
 
       // get the relations from element
       stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);

--- a/src/AssembleContinuityElemOpenSolverAlgorithm.C
+++ b/src/AssembleContinuityElemOpenSolverAlgorithm.C
@@ -164,9 +164,9 @@ AssembleContinuityElemOpenSolverAlgorithm::execute()
 
     // face master element
     MasterElement *meFC = realm_.get_surface_master_element(b.topology());
-    const int nodesPerFace = meFC->nodesPerElement_;
+    const int nodesPerFace = b.topology().num_nodes();
     const int numScsBip = meFC->numIntPoints_;
-    std::vector<int> face_node_ordinal_vec(nodesPerFace);
+
 
     // resize some things; matrix related
     const int lhsSize = nodesPerElement*nodesPerElement;
@@ -232,8 +232,8 @@ AssembleContinuityElemOpenSolverAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(face);
-      int num_face_nodes = realm_.num_side_nodes_all(face);
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      int num_face_nodes = bulk_data.num_nodes(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -257,14 +257,14 @@ AssembleContinuityElemOpenSolverAlgorithm::execute()
       const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);
 
       // extract the connected element to this exposed face; should be single in size!
-      const stk::mesh::Entity* face_elem_rels = realm_.face_elem_map(face);
+      const stk::mesh::Entity* face_elem_rels = bulk_data.begin_elements(face);
       ThrowAssert( bulk_data.num_elements(face) == 1 );
 
-      // get element; its face ordinal number and populate face_node_ordinal_vec
+      // get element; its face ordinal number and populate face_node_ordinals
       stk::mesh::Entity element = face_elem_rels[0];
       const stk::mesh::ConnectivityOrdinal* face_elem_ords = bulk_data.begin_element_ordinals(face);
       const int face_ordinal = face_elem_ords[0];
-      realm_.side_node_ordinals_all(theElemTopo,face_ordinal,face_node_ordinal_vec);
+      const int *face_node_ordinals = meSCS->side_node_ordinals(face_ordinal);
 
       // mapping from ip to nodes for this ordinal
       const int *ipNodeMap = meSCS->ipNodeMap(face_ordinal);
@@ -313,7 +313,7 @@ AssembleContinuityElemOpenSolverAlgorithm::execute()
         double pBip = 0.0;
         const int offSetSF_face = ip*nodesPerFace;
         for ( int ic = 0; ic < nodesPerFace; ++ic ) {
-          const int fn = face_node_ordinal_vec[ic];
+          const int fn = face_node_ordinals[ic];
           const double r = p_face_shape_function[offSetSF_face+ic];
           const double rhoIC = p_density[ic];
           rhoBip += r*rhoIC;

--- a/src/AssembleContinuityInflowSolverAlgorithm.C
+++ b/src/AssembleContinuityInflowSolverAlgorithm.C
@@ -160,9 +160,9 @@ AssembleContinuityInflowSolverAlgorithm::execute()
       double * areaVec = stk::mesh::field_data(*exposedAreaVec_, b, k);
 
       // face node relations for nodal gather
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(b,k);
+      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
 
-      int num_nodes = realm_.num_side_nodes_all(b,k);
+      int num_nodes = b.num_nodes(k);
       for ( int ni = 0; ni < num_nodes; ++ni ) {
 
         // get the node and form connected_node

--- a/src/AssembleContinuityNonConformalSolverAlgorithm.C
+++ b/src/AssembleContinuityNonConformalSolverAlgorithm.C
@@ -189,8 +189,8 @@ AssembleContinuityNonConformalSolverAlgorithm::execute()
   std::vector<double> ws_o_det_j;
   std::vector <double > ws_c_general_shape_function;
   std::vector <double > ws_o_general_shape_function;
-  std::vector<int> ws_c_face_node_ordinals;
-  std::vector<int> ws_o_face_node_ordinals;
+
+
 
   // deal with state
   ScalarFieldType &pressureNp1 = pressure_->field_of_state(stk::mesh::StateNP1);
@@ -222,8 +222,6 @@ AssembleContinuityNonConformalSolverAlgorithm::execute()
         stk::mesh::Entity opposingFace = dgInfo->opposingFace_;
         stk::mesh::Entity currentElement = dgInfo->currentElement_;
         stk::mesh::Entity opposingElement = dgInfo->opposingElement_;
-        stk::topology currentElementTopo = dgInfo->currentElementTopo_;
-        stk::topology opposingElementTopo = dgInfo->opposingElementTopo_;
         const int currentFaceOrdinal = dgInfo->currentFaceOrdinal_;
         const int opposingFaceOrdinal = dgInfo->opposingFaceOrdinal_;
 
@@ -267,8 +265,8 @@ AssembleContinuityNonConformalSolverAlgorithm::execute()
         ws_o_general_shape_function.resize(opposingNodesPerFace);
         
         // face node identification
-        ws_c_face_node_ordinals.resize(currentNodesPerFace);
-        ws_o_face_node_ordinals.resize(opposingNodesPerFace);
+        
+        
 
         // algorithm related; element; dndx will be at a single gauss point
         ws_c_elem_pressure.resize(currentNodesPerElement);
@@ -307,7 +305,7 @@ AssembleContinuityNonConformalSolverAlgorithm::execute()
         double *p_o_dndx = &ws_o_dndx[0];
         
         // populate current face_node_ordinals
-        currentElementTopo.side_node_ordinals(currentFaceOrdinal, ws_c_face_node_ordinals.begin());
+        const int *c_face_node_ordinals = meSCSCurrent->side_node_ordinals(currentFaceOrdinal);
 
         // gather current face data
         stk::mesh::Entity const* current_face_node_rels = bulk_data.begin_nodes(currentFace);
@@ -328,7 +326,7 @@ AssembleContinuityNonConformalSolverAlgorithm::execute()
         }
                 
         // populate opposing face_node_ordinals
-        opposingElementTopo.side_node_ordinals(opposingFaceOrdinal, ws_o_face_node_ordinals.begin());
+        const int *o_face_node_ordinals = meSCSOpposing->side_node_ordinals(opposingFaceOrdinal);
 
         // gather opposing face data
         stk::mesh::Entity const* opposing_face_node_rels = bulk_data.begin_nodes(opposingFace);
@@ -418,7 +416,7 @@ AssembleContinuityNonConformalSolverAlgorithm::execute()
         // current inverse length scale; can loop over face nodes to avoid "nodesOnFace" array
         double currentInverseLength = 0.0;
         for ( int ic = 0; ic < current_num_face_nodes; ++ic ) {
-          const int faceNodeNumber = ws_c_face_node_ordinals[ic];
+          const int faceNodeNumber = c_face_node_ordinals[ic];
           const int offSetDnDx = faceNodeNumber*nDim; // single intg. point
           for ( int j = 0; j < nDim; ++j ) {
             const double nxj = p_cNx[j];
@@ -430,7 +428,7 @@ AssembleContinuityNonConformalSolverAlgorithm::execute()
         // opposing inverse length scale; can loop over face nodes to avoid "nodesOnFace" array
         double opposingInverseLength = 0.0;
         for ( int ic = 0; ic < opposing_num_face_nodes; ++ic ) {
-          const int faceNodeNumber = ws_o_face_node_ordinals[ic];
+          const int faceNodeNumber = o_face_node_ordinals[ic];
           const int offSetDnDx = faceNodeNumber*nDim; // single intg. point
           for ( int j = 0; j < nDim; ++j ) {
             const double nxj = p_oNx[j];
@@ -574,7 +572,7 @@ AssembleContinuityNonConformalSolverAlgorithm::execute()
                              + penaltyIp*(currentPressureBip - opposingPressureBip))*c_amag;
         
         // form residual
-        const int nn = ws_c_face_node_ordinals[currentGaussPointId];
+        const int nn = c_face_node_ordinals[currentGaussPointId];
         p_rhs[nn] -= mdot/projTimeScale;
 
         // set-up row for matrix
@@ -584,7 +582,7 @@ AssembleContinuityNonConformalSolverAlgorithm::execute()
         // sensitivities; current face (penalty); use general shape function for this single ip
         meFCCurrent->general_shape_fcn(1, &currentIsoParCoords[0], &ws_c_general_shape_function[0]);
         for ( int ic = 0; ic < currentNodesPerFace; ++ic ) {
-          const int icnn = ws_c_face_node_ordinals[ic];
+          const int icnn = c_face_node_ordinals[ic];
           const double r = p_c_general_shape_function[ic];
           p_lhs[rowR+icnn] += r*lhsFac;
         }
@@ -604,7 +602,7 @@ AssembleContinuityNonConformalSolverAlgorithm::execute()
         // sensitivities; opposing face (penalty); use general shape function for this single ip
         meFCOpposing->general_shape_fcn(1, &opposingIsoParCoords[0], &ws_o_general_shape_function[0]);
         for ( int ic = 0; ic < opposingNodesPerFace; ++ic ) {
-          const int icnn = ws_o_face_node_ordinals[ic];
+          const int icnn = o_face_node_ordinals[ic];
           const double r = p_o_general_shape_function[ic];
           p_lhs[rowR+icnn+currentNodesPerElement] -= r*lhsFac;
         }

--- a/src/AssembleHeatCondIrradWallSolverAlgorithm.C
+++ b/src/AssembleHeatCondIrradWallSolverAlgorithm.C
@@ -147,9 +147,9 @@ AssembleHeatCondIrradWallSolverAlgorithm::execute()
       double * areaVec = stk::mesh::field_data(*exposedAreaVec_, b, k);
 
       // face node relations for nodal gather
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(b,k);
+      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
       
-      int num_nodes = realm_.num_side_nodes_all(b,k);
+      int num_nodes = b.num_nodes(k);
       for ( int ni = 0; ni < num_nodes; ++ni ) {
 
         // get the node and form connected_node

--- a/src/AssembleHeatCondWallSolverAlgorithm.C
+++ b/src/AssembleHeatCondWallSolverAlgorithm.C
@@ -148,9 +148,9 @@ AssembleHeatCondWallSolverAlgorithm::execute()
       double * areaVec = stk::mesh::field_data(*exposedAreaVec_, b, k);
 
       // face node relations for nodal gather
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(b,k);;
+      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
       
-      int num_nodes = realm_.num_side_nodes_all(b,k);
+      int num_nodes = b.num_nodes(k);
       for ( int ni = 0; ni < num_nodes; ++ni ) {
 
         // get the node and form connected_node

--- a/src/AssembleMomentumEdgeOpenSolverAlgorithm.C
+++ b/src/AssembleMomentumEdgeOpenSolverAlgorithm.C
@@ -137,7 +137,7 @@ AssembleMomentumEdgeOpenSolverAlgorithm::execute()
 
     // size some things that are useful
     const int num_face_nodes = b.topology().num_nodes();
-    std::vector<int> face_node_ordinals(num_face_nodes);
+    
 
     const stk::mesh::Bucket::size_type length = b.size();
 
@@ -160,7 +160,7 @@ AssembleMomentumEdgeOpenSolverAlgorithm::execute()
       // get element; its face ordinal number and populate face_node_ordinals
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = b.begin_element_ordinals(k)[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
+      const int *face_node_ordinals = meSCS->side_node_ordinals(face_ordinal);
 
       // get the relations; populate connected nodes
       stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);

--- a/src/AssembleMomentumEdgeSymmetrySolverAlgorithm.C
+++ b/src/AssembleMomentumEdgeSymmetrySolverAlgorithm.C
@@ -131,7 +131,7 @@ AssembleMomentumEdgeSymmetrySolverAlgorithm::execute()
 
     // size some things that are useful
     const int num_face_nodes = b.topology().num_nodes();
-    std::vector<int> face_node_ordinals(num_face_nodes);
+    
 
     const stk::mesh::Bucket::size_type length = b.size();
 
@@ -153,7 +153,7 @@ AssembleMomentumEdgeSymmetrySolverAlgorithm::execute()
       // get element; its face ordinal number and populate face_node_ordinals
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = b.begin_element_ordinals(k)[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
+      const int *face_node_ordinals = meSCS->side_node_ordinals(face_ordinal);
 
       // get the relations; populate connected nodes
       stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);

--- a/src/AssembleMomentumElemOpenSolverAlgorithm.C
+++ b/src/AssembleMomentumElemOpenSolverAlgorithm.C
@@ -169,7 +169,7 @@ AssembleMomentumElemOpenSolverAlgorithm::execute()
     MasterElement *meFC = realm_.get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
     const int numScsBip = meFC->numIntPoints_;
-    std::vector<int> face_node_ordinal_vec(nodesPerFace);
+
 
     // resize some things; matrix related
     const int lhsSize = nodesPerElement*nDim*nodesPerElement*nDim;
@@ -226,8 +226,8 @@ AssembleMomentumElemOpenSolverAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(face);
-      int num_face_nodes = realm_.num_side_nodes_all(face);
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      int num_face_nodes = bulk_data.num_nodes(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -255,14 +255,14 @@ AssembleMomentumElemOpenSolverAlgorithm::execute()
       const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);
 
       // extract the connected element to this exposed face; should be single in size!
-      stk::mesh::Entity const * face_elem_rels = realm_.face_elem_map(face);
+      stk::mesh::Entity const * face_elem_rels = bulk_data.begin_elements(face);
       ThrowAssert( bulk_data.num_elements(face) == 1 );
 
-      // get element; its face ordinal number and populate face_node_ordinal_vec
+      // get element; its face ordinal number and populate face_node_ordinals
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = bulk_data.begin_element_ordinals(face)[0];
 
-      realm_.side_node_ordinals_all(theElemTopo,face_ordinal,face_node_ordinal_vec);
+      const int *face_node_ordinals = meSCS->side_node_ordinals(face_ordinal);
 
       // mapping from ip to nodes for this ordinal; 
       const int *ipNodeMap = meSCS->ipNodeMap(face_ordinal); // use with elem_node_rels
@@ -328,7 +328,7 @@ AssembleMomentumElemOpenSolverAlgorithm::execute()
           const double r = p_face_shape_function[offSetSF_face+ic];
           viscBip += r*p_viscosity[ic];
           const int offSetFN = ic*nDim;
-          const int nn = face_node_ordinal_vec[ic];
+          const int nn = face_node_ordinals[ic];
           const int offSetEN = nn*nDim;
           for ( int j = 0; j < nDim; ++j ) {
             p_uspecBip[j] += r*p_bcVelocity[offSetFN+j];
@@ -406,7 +406,7 @@ AssembleMomentumElemOpenSolverAlgorithm::execute()
             const double fac = tmdot*(pecfac*om_alphaUpw+om_pecfac);
             for ( int ic = 0; ic < nodesPerFace; ++ic ) {
               const double r = p_face_shape_function[offSetSF_face+ic];
-              const int nn = face_node_ordinal_vec[ic];
+              const int nn = face_node_ordinals[ic];
               p_lhs[rowR+nn*nDim+i] += r*fac;
             }
           }
@@ -448,7 +448,7 @@ AssembleMomentumElemOpenSolverAlgorithm::execute()
               double fac = tmdot*(pecfac*om_alphaUpw+om_pecfac*nfEntrain)*nxinxj;
               for ( int ic = 0; ic < nodesPerFace; ++ic ) {
                 const double r = p_face_shape_function[offSetSF_face+ic];
-                const int nn = face_node_ordinal_vec[ic];
+                const int nn = face_node_ordinals[ic];
                 p_lhs[rowR+nn*nDim+j] += r*fac;
               }
 

--- a/src/AssembleMomentumElemSymmetrySolverAlgorithm.C
+++ b/src/AssembleMomentumElemSymmetrySolverAlgorithm.C
@@ -170,8 +170,8 @@ AssembleMomentumElemSymmetrySolverAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(face);
-      int num_face_nodes = realm_.num_side_nodes_all(face);
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      int num_face_nodes = bulk_data.num_nodes(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -184,7 +184,7 @@ AssembleMomentumElemSymmetrySolverAlgorithm::execute()
       const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);
 
       // extract the connected element to this exposed face; should be single in size!
-      stk::mesh::Entity const * face_elem_rels = realm_.face_elem_map(face);
+      stk::mesh::Entity const * face_elem_rels = bulk_data.begin_elements(face);
       ThrowAssert( bulk_data.num_elements(face) == 1 );
 
       // get element; its face ordinal number

--- a/src/AssembleMomentumNonConformalSolverAlgorithm.C
+++ b/src/AssembleMomentumNonConformalSolverAlgorithm.C
@@ -161,8 +161,8 @@ AssembleMomentumNonConformalSolverAlgorithm::execute()
   std::vector<double> ws_o_det_j;
   std::vector <double > ws_c_general_shape_function;
   std::vector <double > ws_o_general_shape_function;
-  std::vector<int> ws_c_face_node_ordinals;
-  std::vector<int> ws_o_face_node_ordinals;
+
+
 
   // deal with state
   VectorFieldType &velocityNp1 = velocity_->field_of_state(stk::mesh::StateNP1);
@@ -194,8 +194,6 @@ AssembleMomentumNonConformalSolverAlgorithm::execute()
         stk::mesh::Entity opposingFace = dgInfo->opposingFace_;
         stk::mesh::Entity currentElement = dgInfo->currentElement_;
         stk::mesh::Entity opposingElement = dgInfo->opposingElement_;
-        stk::topology currentElementTopo = dgInfo->currentElementTopo_;
-        stk::topology opposingElementTopo = dgInfo->opposingElementTopo_;
         const int currentFaceOrdinal = dgInfo->currentFaceOrdinal_;
         const int opposingFaceOrdinal = dgInfo->opposingFaceOrdinal_;
         
@@ -244,10 +242,6 @@ AssembleMomentumNonConformalSolverAlgorithm::execute()
         ws_c_general_shape_function.resize(currentNodesPerFace);
         ws_o_general_shape_function.resize(opposingNodesPerFace);
         
-        // face node identification
-        ws_c_face_node_ordinals.resize(currentNodesPerFace);
-        ws_o_face_node_ordinals.resize(opposingNodesPerFace);
-
         // pointers
         double *p_lhs = &lhs[0];
         double *p_rhs = &rhs[0];
@@ -268,7 +262,7 @@ AssembleMomentumNonConformalSolverAlgorithm::execute()
         double *p_o_dndx = &ws_o_dndx[0];
    
         // populate current face_node_ordinals
-        currentElementTopo.side_node_ordinals(currentFaceOrdinal, ws_c_face_node_ordinals.begin());
+        const int *c_face_node_ordinals = meSCSCurrent->side_node_ordinals(currentFaceOrdinal);
 
         // gather current face data
         stk::mesh::Entity const* current_face_node_rels = bulk_data.begin_nodes(currentFace);
@@ -286,7 +280,7 @@ AssembleMomentumNonConformalSolverAlgorithm::execute()
         }
 
         // populate opposing face_node_ordinals
-        opposingElementTopo.side_node_ordinals(opposingFaceOrdinal, ws_o_face_node_ordinals.begin());
+        const int *o_face_node_ordinals = meSCSOpposing->side_node_ordinals(opposingFaceOrdinal);
         
         // gather opposing face data
         stk::mesh::Entity const* opposing_face_node_rels = bulk_data.begin_nodes(opposingFace);
@@ -374,7 +368,7 @@ AssembleMomentumNonConformalSolverAlgorithm::execute()
         // current inverse length scale; can loop over face nodes to avoid "nodesOnFace" array
         double currentInverseLength = 0.0;
         for ( int ic = 0; ic < current_num_face_nodes; ++ic ) {
-          const int faceNodeNumber = ws_c_face_node_ordinals[ic];
+          const int faceNodeNumber = c_face_node_ordinals[ic];
           const int offSetDnDx = faceNodeNumber*nDim; // single intg. point
           for ( int j = 0; j < nDim; ++j ) {
             const double nxj = p_cNx[j];
@@ -386,7 +380,7 @@ AssembleMomentumNonConformalSolverAlgorithm::execute()
         // opposing inverse length scale; can loop over face nodes to avoid "nodesOnFace" array
         double opposingInverseLength = 0.0;
         for ( int ic = 0; ic < opposing_num_face_nodes; ++ic ) {
-          const int faceNodeNumber = ws_o_face_node_ordinals[ic];
+          const int faceNodeNumber = o_face_node_ordinals[ic];
           const int offSetDnDx = faceNodeNumber*nDim; // single intg. point
           for ( int j = 0; j < nDim; ++j ) {
             const double nxj = p_oNx[j];
@@ -503,7 +497,7 @@ AssembleMomentumNonConformalSolverAlgorithm::execute()
             : 0.5*tmdot*(currentUBip[i] + opposingUBip[i]);
 
           // assemble residual; form proper rhs index for current face assembly
-          const int nn = ws_c_face_node_ordinals[currentGaussPointId];
+          const int nn = c_face_node_ordinals[currentGaussPointId];
           const int indexR = nn*nDim + i;
           p_rhs[indexR] -= ((dsFactor_*ncDiffFlux + penaltyIp*(currentUBip[i]-opposingUBip[i]))*c_amag + ncAdv*dsFactor_);
 
@@ -514,7 +508,7 @@ AssembleMomentumNonConformalSolverAlgorithm::execute()
           double lhsFac = penaltyIp*c_amag;
           meFCCurrent->general_shape_fcn(1, &currentIsoParCoords[0], &ws_c_general_shape_function[0]);
           for ( int ic = 0; ic < currentNodesPerFace; ++ic ) {
-            const int icNdim = ws_c_face_node_ordinals[ic]*nDim;
+            const int icNdim = c_face_node_ordinals[ic]*nDim;
             const double r = p_c_general_shape_function[ic];
             p_lhs[rowR+icNdim+i] += r*(lhsFac+0.5*tmdot);
           }
@@ -539,7 +533,7 @@ AssembleMomentumNonConformalSolverAlgorithm::execute()
           // sensitivities; opposing face (penalty and advection); use general shape function for this single ip
           meFCOpposing->general_shape_fcn(1, &opposingIsoParCoords[0], &ws_o_general_shape_function[0]);
           for ( int ic = 0; ic < opposingNodesPerFace; ++ic ) {
-            const int icNdim = (ws_o_face_node_ordinals[ic]+currentNodesPerElement)*nDim;
+            const int icNdim = (o_face_node_ordinals[ic]+currentNodesPerElement)*nDim;
             const double r = p_o_general_shape_function[ic];
             p_lhs[rowR+icNdim+i] -= r*(lhsFac-0.5*tmdot);
           }          

--- a/src/AssembleMomentumWallFunctionSolverAlgoirthm.C
+++ b/src/AssembleMomentumWallFunctionSolverAlgoirthm.C
@@ -76,6 +76,7 @@ void
 AssembleMomentumWallFunctionSolverAlgorithm::execute()
 {
 
+  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -176,7 +177,7 @@ AssembleMomentumWallFunctionSolverAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(face);
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
       for ( int ni = 0; ni < nodesPerFace; ++ni ) {
         stk::mesh::Entity node = face_node_rels[ni];
         connected_nodes[ni] = node;

--- a/src/AssembleNodalGradBoundaryAlgorithm.C
+++ b/src/AssembleNodalGradBoundaryAlgorithm.C
@@ -109,8 +109,8 @@ AssembleNodalGradBoundaryAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(b,k);
-      int num_nodes = realm_.num_side_nodes_all(b,k);
+      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
+      int num_nodes = b.num_nodes(k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerFace );

--- a/src/AssembleNodalGradElemContactAlgorithm.C
+++ b/src/AssembleNodalGradElemContactAlgorithm.C
@@ -171,8 +171,7 @@ AssembleNodalGradElemContactAlgorithm::add_elem_gradq()
     // extract master element; hard coded for quad or hex; 
     // quad is always true for 2D while for 3D, either hex or wedge apply
     const stk::topology & theElemTopo = (nDim == 2) ? stk::topology::QUAD_4_2D : stk::topology::HEX_8;
-    const int num_face_nodes = (nDim == 2) ? 2 : 4;
-    std::vector<int> face_node_ordinals(num_face_nodes);
+    
     
     // extract master element for extruded element type
     MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
@@ -215,13 +214,13 @@ AssembleNodalGradElemContactAlgorithm::add_elem_gradq()
       stk::mesh::Entity face = b[k];
       
       // extract the connected element to this exposed face; should be single in size!
-      stk::mesh::Entity const* face_elem_rels = realm_.face_elem_map(face);
+      stk::mesh::Entity const* face_elem_rels = bulk_data.begin_elements(face);
       stk::mesh::ConnectivityOrdinal const* face_elem_ords = bulk_data.begin_element_ordinals(face);
       const int num_elements = bulk_data.num_elements(face);
       ThrowRequire( num_elements == 1 );
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = face_elem_ords[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
+      const int *face_node_ordinals = meSCS->side_node_ordinals(face_ordinal);
       
       // concentrate on loading up the nodal coordinates/scalarQ for the extruded element
       stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);

--- a/src/AssembleNodalGradUBoundaryAlgorithm.C
+++ b/src/AssembleNodalGradUBoundaryAlgorithm.C
@@ -112,8 +112,8 @@ AssembleNodalGradUBoundaryAlgorithm::execute()
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(b,k);
-      int num_nodes = realm_.num_side_nodes_all(b,k);
+      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
+      int num_nodes = b.num_nodes(k);
 
       // sanity check on num nodes
       ThrowAssert( num_nodes == nodesPerFace );

--- a/src/AssembleNodalGradUElemContactAlgorithm.C
+++ b/src/AssembleNodalGradUElemContactAlgorithm.C
@@ -178,8 +178,7 @@ AssembleNodalGradUElemContactAlgorithm::add_elem_gradq()
     // extract master element; hard coded for quad or hex; 
     // quad is always true for 2D while for 3D, either hex or wedge apply
     const stk::topology & theElemTopo = (nDim == 2) ? stk::topology::QUAD_4_2D : stk::topology::HEX_8;
-    const int num_face_nodes = (nDim == 2) ? 2 : 4;
-    std::vector<int> face_node_ordinals(num_face_nodes);
+    
     
     // extract master element for extruded element type
     MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
@@ -222,13 +221,13 @@ AssembleNodalGradUElemContactAlgorithm::add_elem_gradq()
       stk::mesh::Entity face = b[k];
       
       // extract the connected element to this exposed face; should be single in size!
-      stk::mesh::Entity const* face_elem_rels = realm_.face_elem_map(face);
+      stk::mesh::Entity const* face_elem_rels = bulk_data.begin_elements(face);
       stk::mesh::ConnectivityOrdinal const* face_elem_ords = bulk_data.begin_element_ordinals(face);
       const int num_elements = bulk_data.num_elements(face);
       ThrowRequire( num_elements == 1 );
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = face_elem_ords[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
+      const int *face_node_ordinals = meSCS->side_node_ordinals(face_ordinal);
       
       // concentrate on loading up the nodal coordinates/vectorQ for the extruded element
       stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);

--- a/src/AssemblePNGBoundarySolverAlgorithm.C
+++ b/src/AssemblePNGBoundarySolverAlgorithm.C
@@ -135,8 +135,8 @@ AssemblePNGBoundarySolverAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(b,k);;
-      int num_face_nodes = realm_.num_side_nodes_all(b,k);
+      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
+      int num_face_nodes = b.num_nodes(k);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {

--- a/src/AssemblePNGElemSolverAlgorithm.C
+++ b/src/AssemblePNGElemSolverAlgorithm.C
@@ -219,9 +219,9 @@ AssemblePNGElemSolverAlgorithm::execute()
           const double r = p_shape_function_scs[offSetSF+ic];
           scalarQIp += r*p_scalarQ[ic];
         }
-      
+
         // add residual for each component i
-        for ( int i = 0; i < nDim; ++i ) {  
+        for ( int i = 0; i < nDim; ++i ) {
           const int indexL = ilNdim + i;
           const int indexR = irNdim + i;
 
@@ -230,7 +230,7 @@ AssemblePNGElemSolverAlgorithm::execute()
           // right hand side; L and R
           const double rhsFac = -scalarQIp*axi;
           p_rhs[indexL] -= rhsFac;
-          p_rhs[indexR] += rhsFac;  
+          p_rhs[indexR] += rhsFac;
         }
       }
 

--- a/src/AssembleScalarFluxBCSolverAlgorithm.C
+++ b/src/AssembleScalarFluxBCSolverAlgorithm.C
@@ -150,7 +150,7 @@ AssembleScalarFluxBCSolverAlgorithm::execute()
       // gather nodal data off of face
       //======================================
       stk::mesh::Entity const * face_node_rels = bulk_data .begin_nodes(face);
-      int num_face_nodes = realm_.num_side_nodes_all(face);
+      int num_face_nodes = bulk_data.num_nodes(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {

--- a/src/AssembleScalarNonConformalSolverAlgorithm.C
+++ b/src/AssembleScalarNonConformalSolverAlgorithm.C
@@ -158,8 +158,8 @@ AssembleScalarNonConformalSolverAlgorithm::execute()
   std::vector<double> ws_o_det_j;
   std::vector <double > ws_c_general_shape_function;
   std::vector <double > ws_o_general_shape_function;
-  std::vector<int> ws_c_face_node_ordinals;
-  std::vector<int> ws_o_face_node_ordinals;
+
+
 
   // deal with state
   ScalarFieldType &scalarQNp1 = scalarQ_->field_of_state(stk::mesh::StateNP1);
@@ -191,8 +191,6 @@ AssembleScalarNonConformalSolverAlgorithm::execute()
         stk::mesh::Entity opposingFace = dgInfo->opposingFace_;
         stk::mesh::Entity currentElement = dgInfo->currentElement_;
         stk::mesh::Entity opposingElement = dgInfo->opposingElement_;
-        stk::topology currentElementTopo = dgInfo->currentElementTopo_;
-        stk::topology opposingElementTopo = dgInfo->opposingElementTopo_;
         const int currentFaceOrdinal = dgInfo->currentFaceOrdinal_;
         const int opposingFaceOrdinal = dgInfo->opposingFaceOrdinal_;
         
@@ -241,9 +239,6 @@ AssembleScalarNonConformalSolverAlgorithm::execute()
         ws_c_general_shape_function.resize(currentNodesPerFace);
         ws_o_general_shape_function.resize(opposingNodesPerFace);
         
-        // face node identification
-        ws_c_face_node_ordinals.resize(currentNodesPerFace);
-        ws_o_face_node_ordinals.resize(opposingNodesPerFace);
 
         // pointers
         double *p_lhs = &lhs[0];
@@ -265,7 +260,7 @@ AssembleScalarNonConformalSolverAlgorithm::execute()
         double *p_o_dndx = &ws_o_dndx[0];
         
         // populate current face_node_ordinals
-        currentElementTopo.side_node_ordinals(currentFaceOrdinal, ws_c_face_node_ordinals.begin());
+        const int *c_face_node_ordinals = meSCSCurrent->side_node_ordinals(currentFaceOrdinal);
 
         // gather current face data
         stk::mesh::Entity const* current_face_node_rels = bulk_data.begin_nodes(currentFace);
@@ -278,7 +273,7 @@ AssembleScalarNonConformalSolverAlgorithm::execute()
         }
         
         // populate opposing face_node_ordinals
-        opposingElementTopo.side_node_ordinals(opposingFaceOrdinal, ws_o_face_node_ordinals.begin());
+        const int *o_face_node_ordinals = meSCSOpposing->side_node_ordinals(opposingFaceOrdinal);
 
         // gather opposing face data
         stk::mesh::Entity const* opposing_face_node_rels = bulk_data.begin_nodes(opposingFace);
@@ -373,7 +368,7 @@ AssembleScalarNonConformalSolverAlgorithm::execute()
         // current inverse length scale; can loop over face nodes to avoid "nodesOnFace" array
         double currentInverseLength = 0.0;
         for ( int ic = 0; ic < current_num_face_nodes; ++ic ) {
-          const int faceNodeNumber = ws_c_face_node_ordinals[ic];
+          const int faceNodeNumber = c_face_node_ordinals[ic];
           const int offSetDnDx = faceNodeNumber*nDim; // single intg. point
           for ( int j = 0; j < nDim; ++j ) {
             const double nxj = p_cNx[j];
@@ -397,7 +392,7 @@ AssembleScalarNonConformalSolverAlgorithm::execute()
         // opposing inverse length scale; can loop over face nodes to avoid "nodesOnFace" array
         double opposingInverseLength = 0.0;
         for ( int ic = 0; ic < opposing_num_face_nodes; ++ic ) {
-          const int faceNodeNumber = ws_o_face_node_ordinals[ic];
+          const int faceNodeNumber = o_face_node_ordinals[ic];
           const int offSetDnDx = faceNodeNumber*nDim; // single intg. point
           for ( int j = 0; j < nDim; ++j ) {
             const double nxj = p_oNx[j];
@@ -461,7 +456,7 @@ AssembleScalarNonConformalSolverAlgorithm::execute()
           : 0.5*tmdot*(currentScalarQBip + opposingScalarQBip);
        
         // form residual
-        const int nn = ws_c_face_node_ordinals[currentGaussPointId];
+        const int nn = c_face_node_ordinals[currentGaussPointId];
         p_rhs[nn] -= ((dsFactor_*ncDiffFlux + penaltyIp*(currentScalarQBip-opposingScalarQBip))*c_amag + dsFactor_*ncAdv);
 
         // set-up row for matrix
@@ -471,7 +466,7 @@ AssembleScalarNonConformalSolverAlgorithm::execute()
         // sensitivities; current face (penalty and advection); use general shape function for this single ip
         meFCCurrent->general_shape_fcn(1, &currentIsoParCoords[0], &ws_c_general_shape_function[0]);
         for ( int ic = 0; ic < currentNodesPerFace; ++ic ) {
-          const int icnn = ws_c_face_node_ordinals[ic];
+          const int icnn = c_face_node_ordinals[ic];
           const double r = p_c_general_shape_function[ic];
           p_lhs[rowR+icnn] += r*(lhsFac+0.5*tmdot);
         }
@@ -491,7 +486,7 @@ AssembleScalarNonConformalSolverAlgorithm::execute()
         // sensitivities; opposing face (penalty); use general shape function for this single ip
         meFCOpposing->general_shape_fcn(1, &opposingIsoParCoords[0], &ws_o_general_shape_function[0]);
         for ( int ic = 0; ic < opposingNodesPerFace; ++ic ) {
-          const int icnn = ws_o_face_node_ordinals[ic];
+          const int icnn = o_face_node_ordinals[ic];
           const double r = p_o_general_shape_function[ic];
           p_lhs[rowR+icnn+currentNodesPerElement] -= r*(lhsFac-0.5*tmdot);
         }

--- a/src/AveragingInfo.C
+++ b/src/AveragingInfo.C
@@ -25,7 +25,9 @@ namespace nalu{
 //--------------------------------------------------------------------------
 AveragingInfo::AveragingInfo() 
 : computeReynoldsStress_(false),
-  computeTke_(false)
+  computeTke_(false),
+  computeFavreStress_(false),
+  computeFavreTke_(false)
 {
   // does nothing
 }

--- a/src/ComputeGeometryBoundaryAlgorithm.C
+++ b/src/ComputeGeometryBoundaryAlgorithm.C
@@ -83,12 +83,12 @@ ComputeGeometryBoundaryAlgorithm::execute()
       double * areaVec = stk::mesh::field_data(*exposedAreaVec, b, k);
 
       // face node relations for nodal gather
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(b,k);;
+      stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);
 
       //===============================================
       // gather nodal data; this is how we do it now..
       //===============================================
-      int num_nodes = realm_.num_side_nodes_all(b,k);
+      int num_nodes = b.num_nodes(k);
       for ( int ni = 0; ni < num_nodes; ++ni ) {
         stk::mesh::Entity node = face_node_rels[ni];
         double * coords = stk::mesh::field_data(*coordinates, node);

--- a/src/ComputeGeometryExtrusionBoundaryAlgorithm.C
+++ b/src/ComputeGeometryExtrusionBoundaryAlgorithm.C
@@ -94,8 +94,7 @@ ComputeGeometryExtrusionBoundaryAlgorithm::execute()
     // extract master element; hard coded for quad or hex; 
     // quad is always true for 2D while for 3D, either hex or wedge apply
     const stk::topology & theElemTopo = (nDim == 2) ? stk::topology::QUAD_4_2D : stk::topology::HEX_8;
-    const int num_face_nodes = (nDim == 2) ? 2 : 4;
-    std::vector<int> face_node_ordinals(num_face_nodes);
+    
     
     // extract master element for extruded element type
     MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
@@ -133,13 +132,13 @@ ComputeGeometryExtrusionBoundaryAlgorithm::execute()
       stk::mesh::Entity face = b[k];
       
       // extract the connected element to this exposed face; should be single in size!
-      stk::mesh::Entity const* face_elem_rels = realm_.face_elem_map(face);
+      stk::mesh::Entity const* face_elem_rels = bulk_data.begin_elements(face);
       stk::mesh::ConnectivityOrdinal const* face_elem_ords = bulk_data.begin_element_ordinals(face);
       const int num_elements = bulk_data.num_elements(face);
       ThrowRequire( num_elements == 1 );
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = face_elem_ords[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
+      const int *face_node_ordinals = meSCS->side_node_ordinals(face_ordinal);
       
       // concentrate on loading up the nodal coordinates for the extruded element
       stk::mesh::Entity const * face_node_rels = b.begin_nodes(k);

--- a/src/ComputeHeatTransferEdgeWallAlgorithm.C
+++ b/src/ComputeHeatTransferEdgeWallAlgorithm.C
@@ -104,7 +104,7 @@ ComputeHeatTransferEdgeWallAlgorithm::execute()
 
     // size some things that are useful
     const int num_face_nodes = b.topology().num_nodes();
-    std::vector<int> face_node_ordinals(num_face_nodes);
+    
 
     const stk::mesh::Bucket::size_type length   = b.size();
 
@@ -120,7 +120,7 @@ ComputeHeatTransferEdgeWallAlgorithm::execute()
       // get element; its face ordinal number and populate face_node_ordinals
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = b.begin_element_ordinals(k)[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
+      const int *face_node_ordinals = meSCS->side_node_ordinals(face_ordinal);
 
       // get the relations
       stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);

--- a/src/ComputeHeatTransferElemWallAlgorithm.C
+++ b/src/ComputeHeatTransferElemWallAlgorithm.C
@@ -160,8 +160,8 @@ ComputeHeatTransferElemWallAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(face);
-      const int num_face_nodes = realm_.num_side_nodes_all(face);
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      const int num_face_nodes = bulk_data.num_nodes(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {

--- a/src/ComputeLowReynoldsSDRWallAlgorithm.C
+++ b/src/ComputeLowReynoldsSDRWallAlgorithm.C
@@ -111,7 +111,7 @@ ComputeLowReynoldsSDRWallAlgorithm::execute()
 
     // face master element
     MasterElement *meFC = realm_.get_surface_master_element(b.topology());
-    const int nodesPerFace = meFC->nodesPerElement_;
+    const int nodesPerFace = b.topology().num_nodes();
     const int numScsBip = meFC->numIntPoints_;
 
     // mapping from ip to nodes for this ordinal
@@ -143,8 +143,8 @@ ComputeLowReynoldsSDRWallAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(face);
-      int num_face_nodes = realm_.num_side_nodes_all(face);
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      int num_face_nodes = bulk_data.num_nodes(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -159,7 +159,7 @@ ComputeLowReynoldsSDRWallAlgorithm::execute()
       const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);
 
       // extract the connected element to this exposed face; should be single in size!
-      const stk::mesh::Entity* face_elem_rels = realm_.face_elem_map(face);
+      const stk::mesh::Entity* face_elem_rels = bulk_data.begin_elements(face);
       ThrowAssert( bulk_data.num_elements(face) == 1 );
 
       // get element; its face ordinal number

--- a/src/ComputeMdotEdgeOpenAlgorithm.C
+++ b/src/ComputeMdotEdgeOpenAlgorithm.C
@@ -98,7 +98,7 @@ ComputeMdotEdgeOpenAlgorithm::execute()
 
     // size some things that are useful
     const int num_face_nodes = b.topology().num_nodes();
-    std::vector<int> face_node_ordinals(num_face_nodes);
+    
 
     const stk::mesh::Bucket::size_type length   = b.size();
 
@@ -115,7 +115,7 @@ ComputeMdotEdgeOpenAlgorithm::execute()
       // get element; its face ordinal number and populate face_node_ordinals
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = b.begin_element_ordinals(k)[0];
-      theElemTopo.side_node_ordinals(face_ordinal, face_node_ordinals.begin());
+      const int *face_node_ordinals = meSCS->side_node_ordinals(face_ordinal);
 
       // get the relations
       stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);

--- a/src/ComputeMdotElemOpenAlgorithm.C
+++ b/src/ComputeMdotElemOpenAlgorithm.C
@@ -140,9 +140,9 @@ ComputeMdotElemOpenAlgorithm::execute()
 
     // face master element
     MasterElement *meFC = realm_.get_surface_master_element(b.topology());
-    const int nodesPerFace = meFC->nodesPerElement_;
+    const int nodesPerFace = b.topology().num_nodes();
     const int numScsBip = meFC->numIntPoints_;
-    std::vector<int> face_node_ordinal_vec(nodesPerFace);
+
 
     // algorithm related; element
     ws_coordinates.resize(nodesPerElement*nDim);
@@ -186,8 +186,8 @@ ComputeMdotElemOpenAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(face);
-      int num_face_nodes = realm_.num_side_nodes_all(face);
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      int num_face_nodes = bulk_data.num_nodes(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -212,13 +212,13 @@ ComputeMdotElemOpenAlgorithm::execute()
       double * mdot = stk::mesh::field_data(*openMassFlowRate_, face);
 
       // extract the connected element to this exposed face; should be single in size!
-      const stk::mesh::Entity* face_elem_rels = realm_.face_elem_map(face);
+      const stk::mesh::Entity* face_elem_rels = bulk_data.begin_elements(face);
       ThrowAssert( bulk_data.num_elements(face) == 1 );
 
-      // get element; its face ordinal number and populate face_node_ordinal_vec
+      // get element; its face ordinal number and populate face_node_ordinals
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = bulk_data.begin_element_ordinals(face)[0];
-      realm_.side_node_ordinals_all(theElemTopo,face_ordinal,face_node_ordinal_vec);
+      const int *face_node_ordinals = meSCS->side_node_ordinals(face_ordinal);
 
       //======================================
       // gather nodal data off of element
@@ -260,7 +260,7 @@ ComputeMdotElemOpenAlgorithm::execute()
         double pBip = 0.0;
         const int offSetSF_face = ip*nodesPerFace;
         for ( int ic = 0; ic < nodesPerFace; ++ic ) {
-          const int fn = face_node_ordinal_vec[ic];
+          const int fn = face_node_ordinals[ic];
           const double r = p_face_shape_function[offSetSF_face+ic];
           const double rhoIC = p_density[ic];
           rhoBip += r*rhoIC;

--- a/src/ComputeMdotNonConformalAlgorithm.C
+++ b/src/ComputeMdotNonConformalAlgorithm.C
@@ -150,8 +150,8 @@ ComputeMdotNonConformalAlgorithm::execute()
   std::vector<double> ws_o_dndx;
   std::vector<double> ws_c_det_j;
   std::vector<double> ws_o_det_j;
-  std::vector<int> ws_c_face_node_ordinals;
-  std::vector<int> ws_o_face_node_ordinals;
+
+
 
   // deal with state
   ScalarFieldType &pressureNp1 = pressure_->field_of_state(stk::mesh::StateNP1);
@@ -183,8 +183,6 @@ ComputeMdotNonConformalAlgorithm::execute()
         stk::mesh::Entity opposingFace = dgInfo->opposingFace_;
         stk::mesh::Entity currentElement = dgInfo->currentElement_;
         stk::mesh::Entity opposingElement = dgInfo->opposingElement_;
-        stk::topology currentElementTopo = dgInfo->currentElementTopo_;
-        stk::topology opposingElementTopo = dgInfo->opposingElementTopo_;
         const int currentFaceOrdinal = dgInfo->currentFaceOrdinal_;
         const int opposingFaceOrdinal = dgInfo->opposingFaceOrdinal_;
         
@@ -218,10 +216,6 @@ ComputeMdotNonConformalAlgorithm::execute()
         ws_c_density.resize(currentNodesPerFace);
         ws_o_density.resize(opposingNodesPerFace);
        
-        // face node identification
-        ws_c_face_node_ordinals.resize(currentNodesPerFace);
-        ws_o_face_node_ordinals.resize(opposingNodesPerFace);
-
         // algorithm related; element; dndx will be at a single gauss point
         ws_c_elem_pressure.resize(currentNodesPerElement);
         ws_o_elem_pressure.resize(opposingNodesPerElement);
@@ -253,7 +247,7 @@ ComputeMdotNonConformalAlgorithm::execute()
         double *p_o_dndx = &ws_o_dndx[0];
         
         // populate current face_node_ordinals
-        currentElementTopo.side_node_ordinals(currentFaceOrdinal, ws_c_face_node_ordinals.begin());
+        const int *c_face_node_ordinals = meSCSCurrent->side_node_ordinals(currentFaceOrdinal);
 
         // gather current face data
         stk::mesh::Entity const* current_face_node_rels = bulk_data.begin_nodes(currentFace);
@@ -274,7 +268,7 @@ ComputeMdotNonConformalAlgorithm::execute()
         }
         
         // populate opposing face_node_ordinals
-        opposingElementTopo.side_node_ordinals(opposingFaceOrdinal, ws_o_face_node_ordinals.begin());
+        const int *o_face_node_ordinals = meSCSOpposing->side_node_ordinals(opposingFaceOrdinal);
 
         // gather opposing face data
         stk::mesh::Entity const* opposing_face_node_rels = bulk_data.begin_nodes(opposingFace);
@@ -360,7 +354,7 @@ ComputeMdotNonConformalAlgorithm::execute()
         // current inverse length scale; can loop over face nodes to avoid "nodesOnFace" array
         double currentInverseLength = 0.0;
         for ( int ic = 0; ic < current_num_face_nodes; ++ic ) {
-          const int faceNodeNumber = ws_c_face_node_ordinals[ic];
+          const int faceNodeNumber = c_face_node_ordinals[ic];
           const int offSetDnDx = faceNodeNumber*nDim; // single intg. point
           for ( int j = 0; j < nDim; ++j ) {
             const double nxj = p_cNx[j];
@@ -372,7 +366,7 @@ ComputeMdotNonConformalAlgorithm::execute()
         // opposing inverse length scale; can loop over face nodes to avoid "nodesOnFace" array
         double opposingInverseLength = 0.0;
         for ( int ic = 0; ic < opposing_num_face_nodes; ++ic ) {
-          const int faceNodeNumber = ws_o_face_node_ordinals[ic];
+          const int faceNodeNumber = o_face_node_ordinals[ic];
           const int offSetDnDx = faceNodeNumber*nDim; // single intg. point
           for ( int j = 0; j < nDim; ++j ) {
             const double nxj = p_oNx[j];

--- a/src/ComputeTurbKineticEnergyWallFunctionAlgorithm.C
+++ b/src/ComputeTurbKineticEnergyWallFunctionAlgorithm.C
@@ -67,6 +67,7 @@ void
 ComputeTurbKineticEnergyWallFunctionAlgorithm::execute()
 {
 
+  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -84,6 +85,8 @@ ComputeTurbKineticEnergyWallFunctionAlgorithm::execute()
         ib != face_buckets.end() ; ++ib ) {
     stk::mesh::Bucket & b = **ib ;
 
+    // face master element; only need the face topo
+    const int nodesPerFace = b.topology().num_nodes();
     const stk::mesh::Bucket::size_type length   = b.size();
 
     for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
@@ -92,8 +95,7 @@ ComputeTurbKineticEnergyWallFunctionAlgorithm::execute()
       stk::mesh::Entity face = b[k];
 
       // get relations to nodes
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(face);
-      const int nodesPerFace = realm_.num_side_nodes_all(face);
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
 
       // pointer to face data
       const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);

--- a/src/ComputeWallFrictionVelocityAlgorithm.C
+++ b/src/ComputeWallFrictionVelocityAlgorithm.C
@@ -134,7 +134,7 @@ ComputeWallFrictionVelocityAlgorithm::execute()
 
     // face master element
     MasterElement *meFC = realm_.get_surface_master_element(b.topology());
-    const int nodesPerFace = meFC->nodesPerElement_;
+    const int nodesPerFace = b.topology().num_nodes();
     const int numScsBip = meFC->numIntPoints_;
 
     // mapping from ip to nodes for this ordinal; face perspective (use with face_node_relations)
@@ -170,8 +170,8 @@ ComputeWallFrictionVelocityAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(face);
-      int num_face_nodes = realm_.num_side_nodes_all(face);
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      int num_face_nodes = bulk_data.num_nodes(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -197,7 +197,7 @@ ComputeWallFrictionVelocityAlgorithm::execute()
       double *wallFrictionVelocityBip = stk::mesh::field_data(*wallFrictionVelocityBip_, face);
 
       // extract the connected element to this exposed face; should be single in size!
-      const stk::mesh::Entity* face_elem_rels = realm_.face_elem_map(face);
+      const stk::mesh::Entity* face_elem_rels = bulk_data.begin_elements(face);
       ThrowAssert( bulk_data.num_elements(face) == 1 );
 
       // get element; its face ordinal number

--- a/src/ComputeWallModelSDRWallAlgorithm.C
+++ b/src/ComputeWallModelSDRWallAlgorithm.C
@@ -97,11 +97,10 @@ ComputeWallModelSDRWallAlgorithm::execute()
 
     // extract master element
     MasterElement *meSCS = realm_.get_surface_master_element(theElemTopo);
-    MasterElement *meFC = realm_.get_surface_master_element(b.topology());
 
     // face master element
-    const int nodesPerFace = meFC->nodesPerElement_;
-    std::vector<int> face_node_ordinal_vec(nodesPerFace);
+    const int nodesPerFace = b.topology().num_nodes();
+
 
     const stk::mesh::Bucket::size_type length   = b.size();
 
@@ -113,7 +112,7 @@ ComputeWallModelSDRWallAlgorithm::execute()
       //======================================
       // gather nodal data off of face; n/a
       //======================================
-      int num_face_nodes = realm_.num_side_nodes_all(face);
+      int num_face_nodes = bulk_data.num_nodes(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
 
@@ -122,13 +121,13 @@ ComputeWallModelSDRWallAlgorithm::execute()
       double *wallFrictionVelocityBip = stk::mesh::field_data(*wallFrictionVelocityBip_, face);
 
       // extract the connected element to this exposed face; should be single in size!
-      const stk::mesh::Entity* face_elem_rels = realm_.face_elem_map(face);
+      const stk::mesh::Entity* face_elem_rels = bulk_data.begin_elements(face);
       ThrowAssert( bulk_data.num_elements(face) == 1 );
 
-      // get element; its face ordinal number and populate face_node_ordinal_vec
+      // get element; its face ordinal number and populate face_node_ordinals
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = bulk_data.begin_element_ordinals(face)[0];
-      realm_.side_node_ordinals_all(theElemTopo,face_ordinal,face_node_ordinal_vec);
+      const int *face_node_ordinals = meSCS->side_node_ordinals(face_ordinal);
 
       // get the relations off of element
       stk::mesh::Entity const * elem_node_rels = bulk_data.begin_nodes(element);
@@ -139,7 +138,7 @@ ComputeWallModelSDRWallAlgorithm::execute()
         const int offSetAveraVec = ip*nDim;
 
         const int opposingNode = meSCS->opposingNodes(face_ordinal,ip);
-        const int nearestNode = face_node_ordinal_vec[ip];
+        const int nearestNode = face_node_ordinals[ip];
 
         // left and right nodes; right is on the face; left is the opposing node
         stk::mesh::Entity nodeL = elem_node_rels[opposingNode];

--- a/src/ContinuityMassElemSuppAlg.C
+++ b/src/ContinuityMassElemSuppAlg.C
@@ -6,7 +6,7 @@
 /*------------------------------------------------------------------------*/
 
 
-#include <MomentumMassBDF2ElemSuppAlg.h>
+#include <ContinuityMassElemSuppAlg.h>
 #include <SupplementalAlgorithm.h>
 #include <FieldTypeDef.h>
 #include <Realm.h>
@@ -24,22 +24,18 @@ namespace nalu{
 //==========================================================================
 // Class Definition
 //==========================================================================
-// MomentumMassBDF2ElemSuppAlg - CMM (BDF2) for momentum equation (u-dof)
+// ContinuityMassElemSuppAlg - CMM (BDF2/BE) for continuity equation (p-dof)
 //==========================================================================
 //--------------------------------------------------------------------------
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
-MomentumMassBDF2ElemSuppAlg::MomentumMassBDF2ElemSuppAlg(
+ContinuityMassElemSuppAlg::ContinuityMassElemSuppAlg(
   Realm &realm)
   : SupplementalAlgorithm(realm),
     bulkData_(&realm.bulk_data()),
-    velocityNm1_(NULL),
-    velocityN_(NULL),
-    velocityNp1_(NULL),
     densityNm1_(NULL),
     densityN_(NULL),
     densityNp1_(NULL),
-    Gjp_(NULL),
     coordinates_(NULL),
     dt_(0.0),
     gamma1_(0.0),
@@ -48,31 +44,20 @@ MomentumMassBDF2ElemSuppAlg::MomentumMassBDF2ElemSuppAlg(
     nDim_(realm_.spatialDimension_),
     useShifted_(false)
 {
-  // save off fields
+  // save off fields; shove state N into Nm1 if this is BE
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  VectorFieldType *velocity = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  velocityNm1_ = &(velocity->field_of_state(stk::mesh::StateNM1));
-  velocityN_ = &(velocity->field_of_state(stk::mesh::StateN));
-  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
   ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  densityNm1_ = &(density->field_of_state(stk::mesh::StateNM1));
+  densityNm1_ = realm_.number_of_states() == 2 ? &(density->field_of_state(stk::mesh::StateN)) : &(density->field_of_state(stk::mesh::StateNM1));
   densityN_ = &(density->field_of_state(stk::mesh::StateN));
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  Gjp_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
   coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
-
-  // scratch vecs
-  uNm1Scv_.resize(nDim_);
-  uNScv_.resize(nDim_);
-  uNp1Scv_.resize(nDim_);
-  GjpScv_.resize(nDim_);
 }
 
 //--------------------------------------------------------------------------
 //-------- elem_resize -----------------------------------------------------
 //--------------------------------------------------------------------------
 void
-MomentumMassBDF2ElemSuppAlg::elem_resize(
+ContinuityMassElemSuppAlg::elem_resize(
   MasterElement */*meSCS*/,
   MasterElement *meSCV)
 {
@@ -81,10 +66,6 @@ MomentumMassBDF2ElemSuppAlg::elem_resize(
 
   // resize
   ws_shape_function_.resize(numScvIp*nodesPerElement);
-  ws_uNm1_.resize(nDim_*nodesPerElement);
-  ws_uN_.resize(nDim_*nodesPerElement);
-  ws_uNp1_.resize(nDim_*nodesPerElement);
-  ws_Gjp_.resize(nDim_*nodesPerElement);
   ws_rhoNp1_.resize(nodesPerElement);
   ws_rhoN_.resize(nodesPerElement);
   ws_rhoNm1_.resize(nodesPerElement);
@@ -102,25 +83,27 @@ MomentumMassBDF2ElemSuppAlg::elem_resize(
 //-------- setup -----------------------------------------------------------
 //--------------------------------------------------------------------------
 void
-MomentumMassBDF2ElemSuppAlg::setup()
+ContinuityMassElemSuppAlg::setup()
 {
   dt_ = realm_.get_time_step();
   gamma1_ = realm_.get_gamma1();
   gamma2_ = realm_.get_gamma2();
-  gamma3_ = realm_.get_gamma3();
+  gamma3_ = realm_.get_gamma3(); // gamma3 may be zero
 }
 
 //--------------------------------------------------------------------------
 //-------- elem_execute ----------------------------------------------------
 //--------------------------------------------------------------------------
 void
-MomentumMassBDF2ElemSuppAlg::elem_execute(
-  double *lhs,
+ContinuityMassElemSuppAlg::elem_execute(
+  double */*lhs*/,
   double *rhs,
   stk::mesh::Entity element,
   MasterElement */*meSCS*/,
   MasterElement *meSCV)
 {
+  const double projTimeScale = dt_/gamma1_;
+  
   // pointer to ME methods
   const int *ipNodeMap = meSCV->ipNodeMap();
   const int nodesPerElement = meSCV->nodesPerElement_;
@@ -135,13 +118,10 @@ MomentumMassBDF2ElemSuppAlg::elem_execute(
 
   for ( int ni = 0; ni < num_nodes; ++ni ) {
     stk::mesh::Entity node = node_rels[ni];
-    // pointers to real data
-    const double * uNm1 = stk::mesh::field_data(*velocityNm1_, node );
-    const double * uN = stk::mesh::field_data(*velocityN_, node );
-    const double * uNp1 = stk::mesh::field_data(*velocityNp1_, node );
-    const double * Gjp = stk::mesh::field_data(*Gjp_, node );
-    const double * coords =  stk::mesh::field_data(*coordinates_, node);
     
+    // pointers to real data
+    const double * coords =  stk::mesh::field_data(*coordinates_, node);
+      
     // gather scalars
     ws_rhoNm1_[ni] = *stk::mesh::field_data(*densityNm1_, node);
     ws_rhoN_[ni] = *stk::mesh::field_data(*densityN_, node);
@@ -149,12 +129,8 @@ MomentumMassBDF2ElemSuppAlg::elem_execute(
 
     // gather vectors
     const int niNdim = ni*nDim_;
-    for ( int j=0; j < nDim_; ++j ) {
-      ws_uNm1_[niNdim+j] = uNm1[j];
-      ws_uN_[niNdim+j] = uN[j];
-      ws_uNp1_[niNdim+j] = uNp1[j];
-      ws_Gjp_[niNdim+j] = Gjp[j];
-      ws_coordinates_[niNdim+j] = coords[j];
+    for ( int i=0; i < nDim_; ++i ) {
+      ws_coordinates_[niNdim+i] = coords[i];
     }
   }
 
@@ -167,16 +143,10 @@ MomentumMassBDF2ElemSuppAlg::elem_execute(
     // nearest node to ip
     const int nearestNode = ipNodeMap[ip];
     
-    // zero out; scalar and vector
+    // zero out; scalar
     double rhoNm1Scv = 0.0;
     double rhoNScv = 0.0;
     double rhoNp1Scv = 0.0;
-    for ( int j =0; j < nDim_; ++j ) {
-      uNm1Scv_[j] = 0.0;
-      uNScv_[j] = 0.0;
-      uNp1Scv_[j] = 0.0;
-      GjpScv_[j] = 0.0;
-    }
       
     const int offSet = ip*nodesPerElement;
     for ( int ic = 0; ic < nodesPerElement; ++ic ) {
@@ -187,45 +157,15 @@ MomentumMassBDF2ElemSuppAlg::elem_execute(
       rhoNm1Scv += r*ws_rhoNm1_[ic];
       rhoNScv += r*ws_rhoN_[ic];
       rhoNp1Scv += r*ws_rhoNp1_[ic];
-
-      // velocity
-      const int icNdim = ic*nDim_;
-      for ( int j = 0; j < nDim_; ++j ) {
-        uNm1Scv_[j] += r*ws_uNm1_[icNdim+j];
-        uNScv_[j] += r*ws_uN_[icNdim+j];
-        uNp1Scv_[j] += r*ws_uNp1_[icNdim+j];
-        GjpScv_[j] += r*ws_Gjp_[icNdim+j];
-      }
     }
 
     // assemble rhs
     const double scV = ws_scv_volume_[ip];
-    const int nnNdim = nearestNode*nDim_;
-    for ( int i = 0; i < nDim_; ++i ) {
-      rhs[nnNdim+i] += 
-        -(gamma1_*rhoNp1Scv*uNp1Scv_[i] + gamma2_*rhoNScv*uNScv_[i] + gamma3_*rhoNm1Scv*uNm1Scv_[i])*scV/dt_
-        -GjpScv_[i]*scV; //ws_Gjp_[nnNdim+i]*scV; 
-    }
-    
-    // manage LHS
-    for ( int ic = 0; ic < nodesPerElement; ++ic ) {
-      
-      const int icNdim = ic*nDim_;
-      
-      // save off shape function
-      const double r = ws_shape_function_[offSet+ic];
-      
-      const double lhsfac = r*gamma1_*rhoNp1Scv*scV/dt_;
-      
-      for ( int i = 0; i < nDim_; ++i ) {
-        const int indexNN = nnNdim + i;
-        const int rowNN = indexNN*nodesPerElement*nDim_;
-        const int rNNiC_i = rowNN+icNdim+i;
-        lhs[rNNiC_i] += lhsfac;
-      }
-    }   
+    rhs[nearestNode] += 
+      -(gamma1_*rhoNp1Scv + gamma2_*rhoNScv + gamma3_*rhoNm1Scv)*scV/dt_/projTimeScale;
+    // manage LHS; n/a
   }
 }
-
+  
 } // namespace nalu
 } // namespace Sierra

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -50,7 +50,7 @@
 #include <ScalarGclNodeSuppAlg.h>
 #include <ScalarMassBackwardEulerNodeSuppAlg.h>
 #include <ScalarMassBDF2NodeSuppAlg.h>
-#include <ScalarMassBDF2ElemSuppAlg.h>
+#include <ScalarMassElemSuppAlg.h>
 #include <ScalarKeNSOElemSuppAlg.h>
 #include <ScalarNSOElemSuppAlg.h>
 #include <Simulation.h>
@@ -392,15 +392,10 @@ EnthalpyEquationSystem::register_interior_algorithm(
         }
         else if (sourceName == "enthalpy_time_derivative" ) {
           useCMM = true;
-          if ( realm_.number_of_states() == 2 ) {
-            throw std::runtime_error("ElemSrcTermsError::enthalpy_time_derivative requires BDF2 activation");
-          }
-          else {
-            suppAlg = new ScalarMassBDF2ElemSuppAlg(realm_, enthalpy_); 
-          }
+          suppAlg = new ScalarMassElemSuppAlg(realm_, enthalpy_); 
         }
         else {
-          throw std::runtime_error("EnthalpyEquationSystem::register_interior_algorithm limited supported element src terms");
+          throw std::runtime_error("EnthalpyElemSrcTerms::Error Source term is not supported: " + sourceName);
         }     
         theAlg->supplementalAlg_.push_back(suppAlg); 
       }
@@ -462,7 +457,7 @@ EnthalpyEquationSystem::register_interior_algorithm(
           suppAlg = new VariableDensityNonIsoEnthalpySrcNodeSuppAlg(realm_);
         }
         else {
-          throw std::runtime_error("EnthalpyEquationSystem::register_interior_algorithm limited supported nodal src terms");
+          throw std::runtime_error("EnthalpyNodalSrcTerms::Error Source term is not supported: " + sourceName);
         }
         // add supplemental algorithm
         theAlg->supplementalAlg_.push_back(suppAlg);

--- a/src/EpetraLinearSystem.C
+++ b/src/EpetraLinearSystem.C
@@ -377,7 +377,7 @@ EpetraLinearSystem::buildFaceElemToNodeGraph(const stk::mesh::PartVector & parts
       const stk::mesh::Entity face = b[k];
 
       // extract the connected element to this exposed face; should be single in size!
-      const stk::mesh::Entity* face_elem_rels = realm_.face_elem_map(face);//face.relations(stk::topology::ELEMENT_RANK);
+      const stk::mesh::Entity* face_elem_rels = bulk_data.begin_elements(face);//face.relations(stk::topology::ELEMENT_RANK);
       ThrowAssert( bulk_data.num_elements(face) == 1 );
 
       // get connected element

--- a/src/EquationSystems.C
+++ b/src/EquationSystems.C
@@ -17,8 +17,6 @@
 #include <Simulation.h>
 #include <SolutionOptions.h>
 
-#include <element_promotion/PromotedPartHelper.h>
-
 // all concrete EquationSystem's
 #include <EnthalpyEquationSystem.h>
 #include <HeatCondEquationSystem.h>
@@ -29,8 +27,6 @@
 #include <TurbKineticEnergyEquationSystem.h>
 #include <pmr/RadiativeTransportEquationSystem.h>
 #include <mesh_motion/MeshDisplacementEquationSystem.h>
-
-
 
 #include <vector>
 
@@ -322,8 +318,9 @@ EquationSystems::register_wall_bc(
     // found the part
     const std::vector<stk::mesh::Part*> & mesh_parts = targetPart->subsets();
     for( std::vector<stk::mesh::Part*>::const_iterator i = mesh_parts.begin();
-        i != mesh_parts.end(); ++i )
+         i != mesh_parts.end(); ++i )
     {
+      ThrowRequire(*i != nullptr);
       stk::mesh::Part * const part = *i ;
       const stk::topology the_topo = part->topology();
 
@@ -335,13 +332,6 @@ EquationSystems::register_wall_bc(
         EquationSystemVector::iterator ii;
         for( ii=equationSystemVector_.begin(); ii!=equationSystemVector_.end(); ++ii )
           (*ii)->register_wall_bc(part, the_topo, wallBCData);
-      }
-
-      if (realm_.doPromotion_) {
-        auto* promotedPart = promoted_part(*part);
-        EquationSystemVector::iterator ii;
-        for( ii=equationSystemVector_.begin(); ii!=equationSystemVector_.end(); ++ii )
-          (*ii)->register_wall_bc(promotedPart, part->topology(), wallBCData);
       }
     }
   }
@@ -379,13 +369,6 @@ EquationSystems::register_inflow_bc(
         for( ii=equationSystemVector_.begin(); ii!=equationSystemVector_.end(); ++ii )       
           (*ii)->register_inflow_bc(part, the_topo, inflowBCData);
       }
-
-      if (realm_.doPromotion_) {
-        auto* promotedPart = promoted_part(*part);
-        EquationSystemVector::iterator ii;
-        for( ii=equationSystemVector_.begin(); ii!=equationSystemVector_.end(); ++ii )
-          (*ii)->register_inflow_bc(promotedPart, part->topology(), inflowBCData);
-      }
     }
   }
 }
@@ -420,13 +403,6 @@ EquationSystems::register_open_bc(
         EquationSystemVector::iterator ii;
         for( ii=equationSystemVector_.begin(); ii!=equationSystemVector_.end(); ++ii )
           (*ii)->register_open_bc(part, the_topo, openBCData);
-      }
-
-      if (realm_.doPromotion_) {
-        auto* promotedPart = promoted_part(*part);
-        EquationSystemVector::iterator ii;
-        for( ii=equationSystemVector_.begin(); ii!=equationSystemVector_.end(); ++ii )
-          (*ii)->register_open_bc(promotedPart, part->topology(), openBCData);
       }
     }
   }

--- a/src/ExtrusionMeshDistanceBoundaryAlgorithm.C
+++ b/src/ExtrusionMeshDistanceBoundaryAlgorithm.C
@@ -231,7 +231,7 @@ ExtrusionMeshDistanceBoundaryAlgorithm::execute()
       const double * areaVec = stk::mesh::field_data(*exposedAreaVec, face);
 
       // face node relations for nodal gather
-      stk::mesh::Entity const* face_node_rels = realm_.begin_side_nodes_all(face);
+      stk::mesh::Entity const* face_node_rels = bulk_data.begin_nodes(face);
 
       // one to one mapping between ips and nodes
       for ( int ip = 0; ip < num_face_nodes; ++ip ) {

--- a/src/HeatCondEquationSystem.C
+++ b/src/HeatCondEquationSystem.C
@@ -350,15 +350,16 @@ HeatCondEquationSystem::register_interior_algorithm(
         std::string sourceName = mapNameVec[k];
         if (sourceName == "steady_2d_thermal" ) {
           SteadyThermalContactSrcNodeSuppAlg *theSrc
-            = new SteadyThermalContactSrcNodeSuppAlg(realm_);
+          = new SteadyThermalContactSrcNodeSuppAlg(realm_);
           theAlg->supplementalAlg_.push_back(theSrc);
-        } else if (sourceName == "steady_3d_thermal" ) {
+        }
+        else if (sourceName == "steady_3d_thermal" ) {
           SteadyThermalContact3DSrcNodeSuppAlg *theSrc
-            = new SteadyThermalContact3DSrcNodeSuppAlg(realm_);
+          = new SteadyThermalContact3DSrcNodeSuppAlg(realm_);
           theAlg->supplementalAlg_.push_back(theSrc);
         }
         else {
-          throw std::runtime_error("HeatCondEquationSystem::only steady_2d_thermal/steady_3d_thermal src term is supported");
+          throw std::runtime_error("HeatCondNodalSrcTerms::Error Source term is not supported: " + sourceName);
         }
       }
     }
@@ -386,15 +387,16 @@ HeatCondEquationSystem::register_interior_algorithm(
         std::string sourceName = mapNameVec[k];
         if (sourceName == "steady_2d_thermal" ) {
           SteadyThermalContactSrcElemSuppAlg *theSrc
-            = new SteadyThermalContactSrcElemSuppAlg(realm_);
+          = new SteadyThermalContactSrcElemSuppAlg(realm_);
           theAlg->supplementalAlg_.push_back(theSrc);
-        } else if (sourceName == "steady_3d_thermal" ) {
+        }
+        else if (sourceName == "steady_3d_thermal" ) {
           SteadyThermalContact3DSrcElemSuppAlg *theSrc
-            = new SteadyThermalContact3DSrcElemSuppAlg(realm_);
+          = new SteadyThermalContact3DSrcElemSuppAlg(realm_);
           theAlg->supplementalAlg_.push_back(theSrc);
         }
         else {
-          throw std::runtime_error("HeatCondEquationSystem::only steady_2d_thermal/steady_3d_thermal element src term is supported");
+          throw std::runtime_error("HeatCondElemSrcTerms::Error Source term is not supported: " + sourceName);
         }
       }
     }
@@ -488,7 +490,8 @@ HeatCondEquationSystem::register_wall_bc(
       // switch on the name found...
       if ( fcnName == "steady_2d_thermal" ) {
         theAuxFunc = new SteadyThermalContactAuxFunction();
-      } else if ( fcnName == "steady_3d_thermal" ) {
+      }
+      else if ( fcnName == "steady_3d_thermal" ) {
         theAuxFunc = new SteadyThermalContact3DAuxFunction();
       }
       else {
@@ -1009,8 +1012,8 @@ HeatCondEquationSystem::register_initial_condition_fcn(
     if ( fcnName == "steady_2d_thermal" ) {
       // create the function
       theAuxFunc = new SteadyThermalContactAuxFunction();      
-    } else if ( fcnName == "steady_3d_thermal" ) {
-      // create the function
+    }
+    else if ( fcnName == "steady_3d_thermal" ) {
       theAuxFunc = new SteadyThermalContact3DAuxFunction();
     }
     else {

--- a/src/MaterialPropertys.C
+++ b/src/MaterialPropertys.C
@@ -21,13 +21,9 @@
 #include <yaml-cpp/yaml.h>
 #include <NaluParsing.h>
 
-// For naming convention
-#include <element_promotion/PromotedPartHelper.h>
-
 // basic c++
 #include <stdexcept>
 #include <map>
-#include <algorithm>
 
 namespace sierra{
 namespace nalu{
@@ -344,18 +340,6 @@ MaterialPropertys::load(const YAML::Node & node)
       }  
     } 
   }
-}
-
-//--------------------------------------------------------------------------
-//-------- switch_to_super_element_target_names ----------------------------
-//--------------------------------------------------------------------------
-void
-MaterialPropertys::switch_to_super_element_target_names()
-{
-  std::transform(targetNames_.begin(), targetNames_.end(), targetNames_.begin(),
-    [](const std::string& name) {
-       return super_element_part_name(name);
-  });
 }
 
 Simulation* MaterialPropertys::root() { return parent()->root(); }

--- a/src/MixtureFractionEquationSystem.C
+++ b/src/MixtureFractionEquationSystem.C
@@ -42,7 +42,7 @@
 #include <ScalarGclNodeSuppAlg.h>
 #include <ScalarMassBackwardEulerNodeSuppAlg.h>
 #include <ScalarMassBDF2NodeSuppAlg.h>
-#include <ScalarMassBDF2ElemSuppAlg.h>
+#include <ScalarMassElemSuppAlg.h>
 #include <ScalarNSOElemSuppAlg.h>
 #include <ScalarKeNSOElemSuppAlg.h>
 #include <Simulation.h>
@@ -290,15 +290,10 @@ MixtureFractionEquationSystem::register_interior_algorithm(
         }
         else if (sourceName == "mixture_fraction_time_derivative" ) {
           useCMM = true;
-          if ( realm_.number_of_states() == 2 ) {
-            throw std::runtime_error("ElemSrcTermsError::mixture_fraction_time_derivative requires BDF2 activation");
-          }
-          else {
-            suppAlg = new ScalarMassBDF2ElemSuppAlg(realm_, mixFrac_);
-          } 
+          suppAlg = new ScalarMassElemSuppAlg(realm_, mixFrac_); 
         }
         else {
-          throw std::runtime_error("ElemSrcTermsError::only support VariableDensity, NSO and time term");
+          throw std::runtime_error("MixtureFractionElemSrcTerms::Error Source term is not supported: " + sourceName);
         }     
         theAlg->supplementalAlg_.push_back(suppAlg); 
       }
@@ -347,7 +342,7 @@ MixtureFractionEquationSystem::register_interior_algorithm(
           suppAlg = new VariableDensityMixFracSrcNodeSuppAlg(realm_);
         }
         else {
-          throw std::runtime_error("MixtureFractionEquationSystem::only gcl source term(s) are supported");
+          throw std::runtime_error("MixtureFractionNodalSrcTerms::Error Source term is not supported: " + sourceName);
         }
         // add supplemental algorithm
         theAlg->supplementalAlg_.push_back(suppAlg);

--- a/src/MomentumActuatorLineSrcNodeSuppAlg.C
+++ b/src/MomentumActuatorLineSrcNodeSuppAlg.C
@@ -1,0 +1,79 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include <MomentumActuatorLineSrcNodeSuppAlg.h>
+#include <SupplementalAlgorithm.h>
+#include <FieldTypeDef.h>
+#include <Realm.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// MomentumActuatorLineSrcNodeSuppAlg - actuator line drag source term
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+MomentumActuatorLineSrcNodeSuppAlg::MomentumActuatorLineSrcNodeSuppAlg(
+  Realm &realm)
+  : SupplementalAlgorithm(realm),
+    actuatorLineSrc_(NULL),
+    actuatorLineSrcLHS_(NULL),
+    dualNodalVolume_(NULL),
+    nDim_(1)
+{
+  // save off fields
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+  actuatorLineSrc_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "actuator_line_source");
+  actuatorLineSrcLHS_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "actuator_line_source_lhs");
+  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  nDim_ = meta_data.spatial_dimension();
+}
+
+//--------------------------------------------------------------------------
+//-------- setup -----------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+MomentumActuatorLineSrcNodeSuppAlg::setup()
+{
+  // nothing to do
+}
+
+//--------------------------------------------------------------------------
+//-------- node_execute ----------------------------------------------------
+//--------------------------------------------------------------------------
+void
+MomentumActuatorLineSrcNodeSuppAlg::node_execute(
+  double *lhs,
+  double *rhs,
+  stk::mesh::Entity node)
+{
+  // single point quadrature
+  const double *src = stk::mesh::field_data(*actuatorLineSrc_, node);
+  const double dualVolume = *stk::mesh::field_data(*dualNodalVolume_, node);
+  const double srcLHS = *stk::mesh::field_data(*actuatorLineSrcLHS_, node);
+ 
+  const int nDim = nDim_;
+  for ( int i = 0; i < nDim; ++i ) {
+    rhs[i] += src[i]*dualVolume;
+    const int row = i*nDim;
+    lhs[row+i] += srcLHS;
+  }
+}
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/MomentumMassElemSuppAlg.C
+++ b/src/MomentumMassElemSuppAlg.C
@@ -6,7 +6,7 @@
 /*------------------------------------------------------------------------*/
 
 
-#include <ScalarMassBDF2ElemSuppAlg.h>
+#include <MomentumMassElemSuppAlg.h>
 #include <SupplementalAlgorithm.h>
 #include <FieldTypeDef.h>
 #include <Realm.h>
@@ -24,22 +24,22 @@ namespace nalu{
 //==========================================================================
 // Class Definition
 //==========================================================================
-// ScalarMassBDF2ElemSuppAlg - CMM (BDF2) for scalar equation
+// MomentumMassElemSuppAlg - CMM (BDF2/BE) for momentum equation (u-dof)
 //==========================================================================
 //--------------------------------------------------------------------------
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
-ScalarMassBDF2ElemSuppAlg::ScalarMassBDF2ElemSuppAlg(
-  Realm &realm,
-  ScalarFieldType *scalarQ)
+MomentumMassElemSuppAlg::MomentumMassElemSuppAlg(
+  Realm &realm)
   : SupplementalAlgorithm(realm),
     bulkData_(&realm.bulk_data()),
-    scalarQNm1_(NULL),
-    scalarQN_(NULL),
-    scalarQNp1_(NULL),
+    velocityNm1_(NULL),
+    velocityN_(NULL),
+    velocityNp1_(NULL),
     densityNm1_(NULL),
     densityN_(NULL),
     densityNp1_(NULL),
+    Gjp_(NULL),
     coordinates_(NULL),
     dt_(0.0),
     gamma1_(0.0),
@@ -48,23 +48,31 @@ ScalarMassBDF2ElemSuppAlg::ScalarMassBDF2ElemSuppAlg(
     nDim_(realm_.spatialDimension_),
     useShifted_(false)
 {
-  // save off fields
+  // save off fields; shove state N into Nm1 if this is BE
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  scalarQNm1_ = &(scalarQ->field_of_state(stk::mesh::StateNM1));
-  scalarQN_ = &(scalarQ->field_of_state(stk::mesh::StateN));
-  scalarQNp1_ = &(scalarQ->field_of_state(stk::mesh::StateNP1));
+  VectorFieldType *velocity = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  velocityNm1_ = realm_.number_of_states() == 2 ? &(velocity->field_of_state(stk::mesh::StateN)) : &(velocity->field_of_state(stk::mesh::StateNM1));
+  velocityN_ = &(velocity->field_of_state(stk::mesh::StateN));
+  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
   ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  densityNm1_ = &(density->field_of_state(stk::mesh::StateNM1));
+  densityNm1_ = realm_.number_of_states() == 2 ? &(density->field_of_state(stk::mesh::StateN)) : &(density->field_of_state(stk::mesh::StateNM1));
   densityN_ = &(density->field_of_state(stk::mesh::StateN));
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
+  Gjp_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
   coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+
+  // scratch vecs
+  uNm1Scv_.resize(nDim_);
+  uNScv_.resize(nDim_);
+  uNp1Scv_.resize(nDim_);
+  GjpScv_.resize(nDim_);
 }
 
 //--------------------------------------------------------------------------
 //-------- elem_resize -----------------------------------------------------
 //--------------------------------------------------------------------------
 void
-ScalarMassBDF2ElemSuppAlg::elem_resize(
+MomentumMassElemSuppAlg::elem_resize(
   MasterElement */*meSCS*/,
   MasterElement *meSCV)
 {
@@ -73,9 +81,10 @@ ScalarMassBDF2ElemSuppAlg::elem_resize(
 
   // resize
   ws_shape_function_.resize(numScvIp*nodesPerElement);
-  ws_qNm1_.resize(nodesPerElement);
-  ws_qN_.resize(nodesPerElement);
-  ws_qNp1_.resize(nodesPerElement);
+  ws_uNm1_.resize(nDim_*nodesPerElement);
+  ws_uN_.resize(nDim_*nodesPerElement);
+  ws_uNp1_.resize(nDim_*nodesPerElement);
+  ws_Gjp_.resize(nDim_*nodesPerElement);
   ws_rhoNp1_.resize(nodesPerElement);
   ws_rhoN_.resize(nodesPerElement);
   ws_rhoNm1_.resize(nodesPerElement);
@@ -93,19 +102,19 @@ ScalarMassBDF2ElemSuppAlg::elem_resize(
 //-------- setup -----------------------------------------------------------
 //--------------------------------------------------------------------------
 void
-ScalarMassBDF2ElemSuppAlg::setup()
+MomentumMassElemSuppAlg::setup()
 {
   dt_ = realm_.get_time_step();
   gamma1_ = realm_.get_gamma1();
   gamma2_ = realm_.get_gamma2();
-  gamma3_ = realm_.get_gamma3();
+  gamma3_ = realm_.get_gamma3(); // gamma3 may be zero
 }
 
 //--------------------------------------------------------------------------
 //-------- elem_execute ----------------------------------------------------
 //--------------------------------------------------------------------------
 void
-ScalarMassBDF2ElemSuppAlg::elem_execute(
+MomentumMassElemSuppAlg::elem_execute(
   double *lhs,
   double *rhs,
   stk::mesh::Entity element,
@@ -126,23 +135,26 @@ ScalarMassBDF2ElemSuppAlg::elem_execute(
 
   for ( int ni = 0; ni < num_nodes; ++ni ) {
     stk::mesh::Entity node = node_rels[ni];
-    
     // pointers to real data
+    const double * uNm1 = stk::mesh::field_data(*velocityNm1_, node );
+    const double * uN = stk::mesh::field_data(*velocityN_, node );
+    const double * uNp1 = stk::mesh::field_data(*velocityNp1_, node );
+    const double * Gjp = stk::mesh::field_data(*Gjp_, node );
     const double * coords =  stk::mesh::field_data(*coordinates_, node);
-  
+    
     // gather scalars
-    ws_qNm1_[ni] = *stk::mesh::field_data(*scalarQNm1_, node);
-    ws_qN_[ni] = *stk::mesh::field_data(*scalarQN_, node);
-    ws_qNp1_[ni] = *stk::mesh::field_data(*scalarQNp1_, node);
-
     ws_rhoNm1_[ni] = *stk::mesh::field_data(*densityNm1_, node);
     ws_rhoN_[ni] = *stk::mesh::field_data(*densityN_, node);
     ws_rhoNp1_[ni] = *stk::mesh::field_data(*densityNp1_, node);
 
     // gather vectors
     const int niNdim = ni*nDim_;
-    for ( int i=0; i < nDim_; ++i ) {
-      ws_coordinates_[niNdim+i] = coords[i];
+    for ( int j=0; j < nDim_; ++j ) {
+      ws_uNm1_[niNdim+j] = uNm1[j];
+      ws_uN_[niNdim+j] = uN[j];
+      ws_uNp1_[niNdim+j] = uNp1[j];
+      ws_Gjp_[niNdim+j] = Gjp[j];
+      ws_coordinates_[niNdim+j] = coords[j];
     }
   }
 
@@ -155,45 +167,65 @@ ScalarMassBDF2ElemSuppAlg::elem_execute(
     // nearest node to ip
     const int nearestNode = ipNodeMap[ip];
     
-    // zero out; scalar
-    double qNm1Scv = 0.0;
-    double qNScv = 0.0;
-    double qNp1Scv = 0.0;
+    // zero out; scalar and vector
     double rhoNm1Scv = 0.0;
     double rhoNScv = 0.0;
     double rhoNp1Scv = 0.0;
+    for ( int j =0; j < nDim_; ++j ) {
+      uNm1Scv_[j] = 0.0;
+      uNScv_[j] = 0.0;
+      uNp1Scv_[j] = 0.0;
+      GjpScv_[j] = 0.0;
+    }
       
     const int offSet = ip*nodesPerElement;
     for ( int ic = 0; ic < nodesPerElement; ++ic ) {
       // save off shape function
       const double r = ws_shape_function_[offSet+ic];
 
-      // scalar q
-      qNm1Scv += r*ws_qNm1_[ic];
-      qNScv += r*ws_qN_[ic];
-      qNp1Scv += r*ws_qNp1_[ic];
-
       // density
       rhoNm1Scv += r*ws_rhoNm1_[ic];
       rhoNScv += r*ws_rhoN_[ic];
       rhoNp1Scv += r*ws_rhoNp1_[ic];
+
+      // velocity
+      const int icNdim = ic*nDim_;
+      for ( int j = 0; j < nDim_; ++j ) {
+        uNm1Scv_[j] += r*ws_uNm1_[icNdim+j];
+        uNScv_[j] += r*ws_uN_[icNdim+j];
+        uNp1Scv_[j] += r*ws_uNp1_[icNdim+j];
+        GjpScv_[j] += r*ws_Gjp_[icNdim+j];
+      }
     }
 
     // assemble rhs
     const double scV = ws_scv_volume_[ip];
-    rhs[nearestNode] += 
-      -(gamma1_*rhoNp1Scv*qNp1Scv + gamma2_*rhoNScv*qNScv + gamma3_*rhoNm1Scv*qNm1Scv)*scV/dt_;
+    const int nnNdim = nearestNode*nDim_;
+    for ( int i = 0; i < nDim_; ++i ) {
+      rhs[nnNdim+i] += 
+        -(gamma1_*rhoNp1Scv*uNp1Scv_[i] + gamma2_*rhoNScv*uNScv_[i] + gamma3_*rhoNm1Scv*uNm1Scv_[i])*scV/dt_
+        -GjpScv_[i]*scV; 
+    }
     
     // manage LHS
     for ( int ic = 0; ic < nodesPerElement; ++ic ) {
+      
+      const int icNdim = ic*nDim_;
+      
       // save off shape function
       const double r = ws_shape_function_[offSet+ic];
+      
       const double lhsfac = r*gamma1_*rhoNp1Scv*scV/dt_;
-      const int rNNiC = nearestNode*nodesPerElement+ic;
-      lhs[rNNiC] += lhsfac;
+      
+      for ( int i = 0; i < nDim_; ++i ) {
+        const int indexNN = nnNdim + i;
+        const int rowNN = indexNN*nodesPerElement*nDim_;
+        const int rNNiC_i = rowNN+icNdim+i;
+        lhs[rNNiC_i] += lhsfac;
+      }
     }   
   }
 }
-  
+
 } // namespace nalu
 } // namespace Sierra

--- a/src/MomentumNSOGradElemSuppAlg.C
+++ b/src/MomentumNSOGradElemSuppAlg.C
@@ -1,0 +1,333 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include <MomentumNSOGradElemSuppAlg.h>
+#include <SupplementalAlgorithm.h>
+#include <FieldTypeDef.h>
+#include <Realm.h>
+#include <master_element/MasterElement.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// MomentumNSOGradElemSuppAlg - NSO for momentum equation
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+MomentumNSOGradElemSuppAlg::MomentumNSOGradElemSuppAlg(
+  Realm &realm,
+  VectorFieldType *velocity,
+  GenericFieldType *Gju,
+  const double fourthFac)
+  : SupplementalAlgorithm(realm),
+    bulkData_(&realm.bulk_data()),
+    velocityNp1_(NULL),
+    densityNp1_(NULL),
+    pressure_(NULL),
+    Gjp_(NULL),
+    velocityRTM_(NULL),
+    coordinates_(NULL),
+    Gju_(Gju),
+    nDim_(realm_.spatialDimension_),
+    Cupw_(0.1),
+    small_(1.0e-16),
+    fourthFac_(fourthFac)
+{
+  // save off fields with and without state
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
+  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
+  pressure_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
+  Gjp_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
+
+  // check for mesh motion for proper velocity
+  const bool meshMotion = realm_.does_mesh_move();
+  if ( meshMotion )
+    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+  else
+    velocityRTM_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+
+  // fixed size
+  ws_dukdxScs_.resize(nDim_);
+  ws_rhoVrtmScs_.resize(nDim_);
+  ws_dpdxScs_.resize(nDim_);
+  ws_GjpScs_.resize(nDim_);
+}
+
+//--------------------------------------------------------------------------
+//-------- elem_resize -----------------------------------------------------
+//--------------------------------------------------------------------------
+void
+MomentumNSOGradElemSuppAlg::elem_resize(
+  MasterElement *meSCS,
+  MasterElement */*meSCV*/)
+{
+  const int nodesPerElement = meSCS->nodesPerElement_;
+  const int numScsIp = meSCS->numIntPoints_;
+
+  // resize; geometry
+  ws_scs_areav_.resize(numScsIp*nDim_);
+  ws_dndx_.resize(nDim_*numScsIp*nodesPerElement);
+  ws_deriv_.resize(nDim_*numScsIp*nodesPerElement);
+  ws_det_j_.resize(numScsIp);
+  ws_shape_function_.resize(numScsIp*nodesPerElement);
+  ws_gUpper_.resize(nDim_*nDim_*numScsIp); // g^ij (covariant)
+  ws_gLower_.resize(nDim_*nDim_*numScsIp); // g_ij (contravariat)
+
+  // resize; fields
+  ws_uNp1_.resize(nDim_*nodesPerElement);
+  ws_rhoNp1_.resize(nodesPerElement);
+  ws_pressure_.resize(nodesPerElement);
+  ws_Gjp_.resize(nDim_*nodesPerElement);
+  ws_velocityRTM_.resize(nDim_*nodesPerElement);
+  ws_coordinates_.resize(nDim_*nodesPerElement);
+  ws_Gju_.resize(nDim_*nDim_*nodesPerElement);
+  
+  // compute shape function
+  meSCS->shape_fcn(&ws_shape_function_[0]);
+}
+
+//--------------------------------------------------------------------------
+//-------- setup -----------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+MomentumNSOGradElemSuppAlg::setup()
+{
+  // nothing to do
+}
+
+//--------------------------------------------------------------------------
+//-------- elem_execute ----------------------------------------------------
+//--------------------------------------------------------------------------
+void
+MomentumNSOGradElemSuppAlg::elem_execute(
+  double *lhs,
+  double *rhs,
+  stk::mesh::Entity element,
+  MasterElement *meSCS,
+  MasterElement */*meSCV*/)
+{
+  // details on this element topo
+  const int nodesPerElement = meSCS->nodesPerElement_;
+  const int numScsIp = meSCS->numIntPoints_;
+  const int *lrscv = meSCS->adjacentNodes();    
+  
+  // gather
+  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
+  int num_nodes = bulkData_->num_nodes(element);
+
+  // sanity check on num nodes
+  ThrowAssert( num_nodes == nodesPerElement );
+
+  for ( int ni = 0; ni < num_nodes; ++ni ) {
+    stk::mesh::Entity node = node_rels[ni];
+    
+    // gather scalars
+    ws_rhoNp1_[ni] = *stk::mesh::field_data(*densityNp1_, node);
+    ws_pressure_[ni] = *stk::mesh::field_data(*pressure_, node);
+
+    // pointers to real data
+    const double * uNp1 = stk::mesh::field_data(*velocityNp1_, node );
+    const double * vrtm = stk::mesh::field_data(*velocityRTM_, node );
+    const double * Gjp = stk::mesh::field_data(*Gjp_, node );
+    const double * coords = stk::mesh::field_data(*coordinates_, node );
+    const double * Gju = stk::mesh::field_data(*Gju_, node );
+
+    // gather vectors
+    const int niNdim = ni*nDim_;
+    // row for ws_Gju
+    const int row_ws_Gju = niNdim*nDim_;
+    for ( int i=0; i < nDim_; ++i ) {
+      ws_uNp1_[niNdim+i] = uNp1[i];
+      ws_velocityRTM_[niNdim+i] = vrtm[i];
+      ws_Gjp_[niNdim+i] = Gjp[i];
+      ws_coordinates_[niNdim+i] = coords[i];
+      // gather tensor projected nodal gradients
+      const int row_Gju = i*nDim_;
+      for ( int j=0; j < nDim_; ++j ) {
+        ws_Gju_[row_ws_Gju+row_Gju+j] = Gju[row_Gju+j];
+      }
+    }
+  }
+  
+  // compute geometry (AGAIN)...
+  double scs_error = 0.0;
+  meSCS->determinant(1, &ws_coordinates_[0], &ws_scs_areav_[0], &scs_error);
+  
+  // compute dndx (AGAIN)...
+  meSCS->grad_op(1, &ws_coordinates_[0], &ws_dndx_[0], &ws_deriv_[0], &ws_det_j_[0], &scs_error);
+
+  // compute gij; requires a proper ws_deriv from above
+  meSCS->gij(&ws_coordinates_[0], &ws_gUpper_[0], &ws_gLower_[0], &ws_deriv_[0]);
+
+  for ( int ip = 0; ip < numScsIp; ++ip ) {
+
+    // left and right nodes for this ip
+    const int il = lrscv[2*ip];
+    const int ir = lrscv[2*ip+1];
+
+    // save off some offsets
+    const int ilNdim = il*nDim_;
+    const int irNdim = ir*nDim_;
+
+    // pointer to gupperij and glowerij
+    const double *p_gUpper = &ws_gUpper_[nDim_*nDim_*ip];
+    const double *p_gLower = &ws_gLower_[nDim_*nDim_*ip];
+
+    // zero out vectors that prevail over all components
+    for ( int i = 0; i < nDim_; ++i ) {
+      ws_rhoVrtmScs_[i] = 0.0;
+      ws_dpdxScs_[i] = 0.0;
+      ws_GjpScs_[i] = 0.0;
+    }
+    
+    // determine scs values of interest
+    const int offSet = ip*nodesPerElement;
+    for ( int ic = 0; ic < nodesPerElement; ++ic ) {
+
+      // save off shape function
+      const double r = ws_shape_function_[offSet+ic];  
+
+      const int icNdim = ic*nDim_;
+      
+      const int row_ws_Gju = icNdim*nDim_;
+  
+      // compute scs derivatives
+      const int offSetDnDx = nDim_*nodesPerElement*ip + icNdim;
+      const double pIC = ws_pressure_[ic];
+      const double rhoIC = ws_rhoNp1_[ic];
+      for ( int j = 0; j < nDim_; ++j ) {
+        const double dnj = ws_dndx_[offSetDnDx+j];
+        const double vrtmj = ws_velocityRTM_[icNdim+j];
+        ws_rhoVrtmScs_[j] += r*rhoIC*vrtmj;
+        ws_dpdxScs_[j] += pIC*dnj;
+        ws_GjpScs_[j] += r*ws_Gjp_[icNdim+j];
+      }
+    }
+    
+    // assemble each component
+    for ( int k = 0; k < nDim_; ++k ) {
+      
+      const int indexL = ilNdim + k;
+      const int indexR = irNdim + k;
+      
+      const int rowL = indexL*nodesPerElement*nDim_;
+      const int rowR = indexR*nodesPerElement*nDim_;
+
+      // zero out vector of local derivatives (duk/dxj)
+      for ( int j = 0; j < nDim_; ++j ) {
+        ws_dukdxScs_[j] = 0.0;
+      }
+    
+      // determine scs values of interest
+      const int offSet = ip*nodesPerElement;
+      for ( int ic = 0; ic < nodesPerElement; ++ic ) {
+        
+        const int icNdim = ic*nDim_;
+
+        // save off shape function
+        const double r = ws_shape_function_[offSet+ic];
+           
+        // save off velocity for component k
+        const double ukNp1 = ws_uNp1_[icNdim+k];
+
+        // compute scs derivatives and flux derivative (adv/diff)
+        const int offSetDnDx = nDim_*nodesPerElement*ip + icNdim;
+        const double rhoIC = ws_rhoNp1_[ic];
+        for ( int j = 0; j < nDim_; ++j ) {
+          const double dnj = ws_dndx_[offSetDnDx+j];
+          const double vrtmj = ws_velocityRTM_[icNdim+j];
+          ws_dukdxScs_[j] += ukNp1*dnj;
+        }
+      }
+      
+      // compute residual for NSO; based on fine scale momentum form used in Continuity
+      const double residualRk = ws_dpdxScs_[k] - ws_GjpScs_[k];
+      
+      // denominator for nu as well as terms for "upwind" nu
+      double gUpperMagGradQ = 0.0;
+      double rhoVrtmiGLowerRhoVrtmj = 0.0;
+      for ( int i = 0; i < nDim_; ++i ) {
+        const double duidxScs = ws_dukdxScs_[i];
+        const double rhoVrtmi = ws_rhoVrtmScs_[i];
+        for ( int j = 0; j < nDim_; ++j ) {
+          gUpperMagGradQ += duidxScs*p_gUpper[i*nDim_+j]*ws_dukdxScs_[j];
+          rhoVrtmiGLowerRhoVrtmj += rhoVrtmi*p_gLower[i*nDim_+j]*ws_rhoVrtmScs_[j];
+        }
+      }      
+      
+      // construct nu from residual
+      const double nuResidual = std::sqrt((residualRk*residualRk)/(gUpperMagGradQ+small_));
+      
+      // construct nu from first-order-like approach; SNL-internal write-up (eq 209)
+      // for now, only include advection as full set of terms is too diffuse
+      const double nuFirstOrder = std::sqrt(rhoVrtmiGLowerRhoVrtmj);
+      
+      // limit based on first order; Cupw_ is a fudge factor similar to Guermond's approach
+      const double nu = std::min(Cupw_*nuFirstOrder, nuResidual);
+      
+      double gijFac = 0.0;
+      for ( int ic = 0; ic < nodesPerElement; ++ic ) {
+
+        // save off shape function
+        const double r = ws_shape_function_[offSet+ic];
+
+        // find the row
+        const int icNdim = ic*nDim_;
+
+        // and column
+        const int rLkC_k = rowL+icNdim+k;
+        const int rRkC_k = rowR+icNdim+k;
+
+        // offset into projected nodal gradient
+        const int row_ws_Gju = icNdim*nDim_;
+
+        // save of some variables
+        const double ukNp1 = ws_uNp1_[ic*nDim_+k];
+        
+        // NSO diffusion-like term; -nu*gUpper*dQ/dxj*ai (residual below)
+        double lhsfac = 0.0;
+        const int offSetDnDx = nDim_*nodesPerElement*ip + ic*nDim_;
+        for ( int i = 0; i < nDim_; ++i ) {
+          const double axi = ws_scs_areav_[ip*nDim_+i];
+          for ( int j = 0; j < nDim_; ++j ) {
+            const double dnxj = ws_dndx_[offSetDnDx+j];
+            const double fac = p_gUpper[i*nDim_+j]*dnxj*axi;
+            const double facGj = r*p_gUpper[i*nDim_+j]*ws_Gju_[row_ws_Gju+k*nDim_+j]*axi;
+            gijFac += fac*ukNp1 - facGj*fourthFac_;
+            lhsfac += -fac;
+          }
+        }
+        
+        // no coupling between components
+        lhs[rLkC_k] += nu*lhsfac;
+        lhs[rRkC_k] -= nu*lhsfac;
+      }
+      
+      // residual; left and right
+      const double residualNSO = -nu*gijFac;
+      rhs[indexL] -= residualNSO;
+      rhs[indexR] += residualNSO;
+    }      
+  }
+}
+  
+} // namespace nalu
+} // namespace Sierra

--- a/src/NonConformalInfo.C
+++ b/src/NonConformalInfo.C
@@ -221,8 +221,8 @@ NonConformalInfo::construct_dgInfo_state()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(face);
-      const int num_face_nodes = realm_.num_side_nodes_all(face);
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
+      const int num_face_nodes = bulk_data.num_nodes(face);
       
       // sanity check on num nodes (low order, P=1, check)
       ThrowAssert( num_face_nodes == numScsBip ); ThrowAssert( num_face_nodes == nodesPerFace );
@@ -235,7 +235,7 @@ NonConformalInfo::construct_dgInfo_state()
       }
 
       // extract the connected element to this exposed face; should be single in size!
-      const stk::mesh::Entity* face_elem_rels = realm_.face_elem_map(face);
+      const stk::mesh::Entity* face_elem_rels = bulk_data.begin_elements(face);
       ThrowAssert( bulk_data.num_elements(face) == 1 );
 
       // get element; its face ordinal number
@@ -325,7 +325,7 @@ NonConformalInfo::determine_elems_to_ghost()
         throw std::runtime_error("no valid entry for face");
       
       // extract the connected element
-      const stk::mesh::Entity* face_elem_rels = realm_.face_elem_map(face);
+      const stk::mesh::Entity* face_elem_rels = bulk_data.begin_elements(face);
       ThrowAssert( bulk_data.num_elements(face) == 1 );
       stk::mesh::Entity element = face_elem_rels[0];
           
@@ -508,8 +508,8 @@ NonConformalInfo::find_possible_face_elements()
       }
 
       // extract elem_node_relations
-      stk::mesh::Entity const* face_node_rels = realm_.begin_side_nodes_all(face);
-      const int num_nodes = realm_.num_side_nodes_all(face);
+      stk::mesh::Entity const* face_node_rels = bulk_data.begin_nodes(face);
+      const int num_nodes = bulk_data.num_nodes(face);
 
       for ( int ni = 0; ni < num_nodes; ++ni ) {
         stk::mesh::Entity node = face_node_rels[ni];

--- a/src/ScalarNSOElemSuppAlg.C
+++ b/src/ScalarNSOElemSuppAlg.C
@@ -80,8 +80,7 @@ ScalarNSOElemSuppAlg::ScalarNSOElemSuppAlg(
 
   // fixed size
   ws_dqdxScs_.resize(nDim_);
-  ws_vrtmScs_.resize(nDim_);
-  ws_rhovScs_.resize(nDim_);
+  ws_rhoVrtmScs_.resize(nDim_);
 }
 
 //--------------------------------------------------------------------------
@@ -221,8 +220,7 @@ ScalarNSOElemSuppAlg::elem_execute(
     // zero out vector
     for ( int i = 0; i < nDim_; ++i ) {
       ws_dqdxScs_[i] = 0.0;
-      ws_vrtmScs_[i] = 0.0;
-      ws_rhovScs_[i] = 0.0;
+      ws_rhoVrtmScs_[i] = 0.0;
     }
     
     // determine scs values of interest
@@ -250,8 +248,7 @@ ScalarNSOElemSuppAlg::elem_execute(
         const double dnj = ws_dndx_[offSetDnDx+j];
         const double vrtmj = ws_velocityRTM_[ic*nDim_+j];
         ws_dqdxScs_[j] += qIC*dnj;
-        ws_vrtmScs_[j] += vrtmj*r;
-        ws_rhovScs_[j] += r*rhoIC*vrtmj;
+        ws_rhoVrtmScs_[j] += r*rhoIC*vrtmj;
         dFdxAdv += rhoIC*vrtmj*qIC*dnj;
         dFdxDiff += diffFluxCoeffIC*ws_Gjq_[ic*nDim_+j]*dnj;
         dFdxCont += rhoIC*vrtmj*dnj;
@@ -264,7 +261,7 @@ ScalarNSOElemSuppAlg::elem_execute(
     // compute residual for NSO; linearized first
     double residualAlt = dFdxAdv - qNp1Scs*dFdxCont;
     for ( int j = 0; j < nDim_; ++j )
-      residualAlt -= ws_rhovScs_[j]*ws_dqdxScs_[j];
+      residualAlt -= ws_rhoVrtmScs_[j]*ws_dqdxScs_[j];
     
     // compute residual for NSO; pde-based second
     const double time = (gamma1_*rhoNp1Scs*qNp1Scs + gamma2_*rhoNScs*qNScs + gamma3_*rhoNm1Scs*qNm1Scs)/dt_;
@@ -273,15 +270,15 @@ ScalarNSOElemSuppAlg::elem_execute(
     // final form
     const double residual = residualAlt*altResFac_ + residualPde*om_altResFac_;
 
-    // demonominator for nu as well as terms for "upwind" nu
+    // denominator for nu as well as terms for "upwind" nu
     double gUpperMagGradQ = 0.0;
-    double uigLoweruj = 0.0;
+    double rhoVrtmiGLowerRhoVrtmj = 0.0;
     for ( int i = 0; i < nDim_; ++i ) {
       const double dqdxScsi = ws_dqdxScs_[i];
-      const double ui = ws_vrtmScs_[i];
+      const double rhoVrtmi = ws_rhoVrtmScs_[i];
       for ( int j = 0; j < nDim_; ++j ) {
         gUpperMagGradQ += dqdxScsi*p_gUpper[i*nDim_+j]*ws_dqdxScs_[j];
-        uigLoweruj += ui*p_gLower[i*nDim_+j]*ws_vrtmScs_[j];
+        rhoVrtmiGLowerRhoVrtmj += rhoVrtmi*p_gLower[i*nDim_+j]*ws_rhoVrtmScs_[j];
       }
     }      
     
@@ -290,7 +287,7 @@ ScalarNSOElemSuppAlg::elem_execute(
     
     // construct nu from first-order-like approach; SNL-internal write-up (eq 209)
     // for now, only include advection as full set of terms is too diffuse
-    const double nuFirstOrder = std::sqrt(rhoNp1Scs*rhoNp1Scs*uigLoweruj);
+    const double nuFirstOrder = std::sqrt(rhoVrtmiGLowerRhoVrtmj);
 
     // limit based on first order; Cupw_ is a fudge factor similar to Guermond's approach
     const double nu = std::min(Cupw_*nuFirstOrder, nuResidual);

--- a/src/SolutionNormPostProcessing.C
+++ b/src/SolutionNormPostProcessing.C
@@ -49,7 +49,8 @@ namespace nalu{
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 SolutionNormPostProcessing::SolutionNormPostProcessing(
-  Realm & realm) 
+  Realm &realm,
+  const YAML::Node &node)
   : realm_(realm),
     outputFrequency_(100),
     totalDofCompSize_(0),
@@ -57,7 +58,8 @@ SolutionNormPostProcessing::SolutionNormPostProcessing(
     w_(12),
     percision_(6)
 {
-  // na
+  // load the data
+  load(node);
 }
 
 //--------------------------------------------------------------------------
@@ -132,9 +134,11 @@ SolutionNormPostProcessing::load(
 //-------- setup -----------------------------------------------------------
 //--------------------------------------------------------------------------
 void
-SolutionNormPostProcessing::setup(
-  const std::vector<std::string> targetNames)
+SolutionNormPostProcessing::setup()
 {
+  // extract target names
+
+  const std::vector<std::string> targetNames = realm_.get_physics_target_names();
   stk::mesh::MetaData & metaData = realm_.meta_data();
 
   // first, loop over all target names, extract the part and push back

--- a/src/SurfaceForceAndMomentAlgorithm.C
+++ b/src/SurfaceForceAndMomentAlgorithm.C
@@ -220,7 +220,7 @@ SurfaceForceAndMomentAlgorithm::execute()
       stk::mesh::Entity face = b[k];
 
       // face node relations
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(face);
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
 
       //======================================
       // gather nodal data off of face
@@ -237,7 +237,7 @@ SurfaceForceAndMomentAlgorithm::execute()
       const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);
 
       // extract the connected element to this exposed face; should be single in size!
-      const stk::mesh::Entity* face_elem_rels = realm_.face_elem_map(face);
+      const stk::mesh::Entity* face_elem_rels = bulk_data.begin_elements(face);
       ThrowAssert( bulk_data.num_elements(face) == 1 );
 
       // get element; its face ordinal number
@@ -410,6 +410,7 @@ SurfaceForceAndMomentAlgorithm::pre_work()
 {
 
   // common
+  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   const int nDim = meta_data.spatial_dimension();
 
@@ -442,7 +443,7 @@ SurfaceForceAndMomentAlgorithm::pre_work()
       stk::mesh::Entity face = b[k];
 
       // face node relations
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(face);
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
 
       // pointer to face data
       const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);

--- a/src/SurfaceForceAndMomentWallFunctionAlgorithm.C
+++ b/src/SurfaceForceAndMomentWallFunctionAlgorithm.C
@@ -135,6 +135,7 @@ SurfaceForceAndMomentWallFunctionAlgorithm::execute()
   if ( !processMe )
     return;
 
+  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -237,7 +238,7 @@ SurfaceForceAndMomentWallFunctionAlgorithm::execute()
       stk::mesh::Entity face = b[k];
 
       // face node relations
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(face);
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
 
       //======================================
       // gather nodal data off of face
@@ -420,6 +421,7 @@ SurfaceForceAndMomentWallFunctionAlgorithm::pre_work()
 {
 
   // common
+  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   const int nDim = meta_data.spatial_dimension();
 
@@ -452,7 +454,7 @@ SurfaceForceAndMomentWallFunctionAlgorithm::pre_work()
       stk::mesh::Entity face = b[k];
 
       // face node relations
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(face);
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
 
       // pointer to face data
       const double * areaVec = stk::mesh::field_data(*exposedAreaVec_, face);

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -44,7 +44,7 @@
 #include <ScalarGclNodeSuppAlg.h>
 #include <ScalarMassBackwardEulerNodeSuppAlg.h>
 #include <ScalarMassBDF2NodeSuppAlg.h>
-#include <ScalarMassBDF2ElemSuppAlg.h>
+#include <ScalarMassElemSuppAlg.h>
 #include <ScalarKeNSOElemSuppAlg.h>
 #include <ScalarNSOElemSuppAlg.h>
 #include <Simulation.h>
@@ -263,15 +263,10 @@ TurbKineticEnergyEquationSystem::register_interior_algorithm(
         }
         else if (sourceName == "turbulent_ke_time_derivative" ) {
           useCMM = true;
-          if ( realm_.number_of_states() == 2 ) {
-            throw std::runtime_error("ElemSrcTermsError::turbulent_ke_time_derivative requires BDF2 activation");
-          }
-          else {
-            suppAlg = new ScalarMassBDF2ElemSuppAlg(realm_, tke_);
-          } 
+          suppAlg = new ScalarMassElemSuppAlg(realm_, tke_);
         }
         else {
-          throw std::runtime_error("TurbKineticEnergyEquationSystem::Error: unsupported source term");
+          throw std::runtime_error("TurbKineticEnergyElemSrcTerms::Error Source term is not supported: " + sourceName);
         }     
         theAlg->supplementalAlg_.push_back(suppAlg); 
       }
@@ -340,7 +335,7 @@ TurbKineticEnergyEquationSystem::register_interior_algorithm(
           suppAlg = new ScalarGclNodeSuppAlg(tke_,realm_);
         }
         else {
-          throw std::runtime_error("TurbKineticEnergyEquationSystem::only gcl source term(s) are supported");
+          throw std::runtime_error("TurbKineticEnergyNodalSrcTerms::Error Source term is not supported: " + sourceName);
         }
         // add supplemental algorithm
         theAlg->supplementalAlg_.push_back(suppAlg);

--- a/src/TurbulenceAveragingPostProcessing.C
+++ b/src/TurbulenceAveragingPostProcessing.C
@@ -116,7 +116,7 @@ TurbulenceAveragingPostProcessing::load(
           }
         }
         
-        // favre
+        // Favre
         const YAML::Node *y_favre = y_spec.FindValue("favre_averaged_variables");
         if (y_favre) {
           size_t varSize = y_favre->size();
@@ -129,11 +129,13 @@ TurbulenceAveragingPostProcessing::load(
           } 
         }
         
-        // check for reynolds stress and tke post processing
+        // check for stress and tke post processing; Reynolds and Favre
         get_if_present(y_spec, "compute_reynolds_stress", avInfo->computeReynoldsStress_, avInfo->computeReynoldsStress_);
         get_if_present(y_spec, "compute_tke", avInfo->computeTke_, avInfo->computeTke_);
-        
-        // we will need Reynolds-averaged velocity if we need to compute TKE
+        get_if_present(y_spec, "compute_favre_stress", avInfo->computeFavreStress_, avInfo->computeFavreStress_);
+        get_if_present(y_spec, "compute_favre_tke", avInfo->computeFavreTke_, avInfo->computeFavreTke_);
+
+        // we will need Reynolds/Favre-averaged velocity if we need to compute TKE
         if ( avInfo->computeTke_ || avInfo->computeReynoldsStress_ ) {
           const std::string velocityName = "velocity";
           if ( std::find(avInfo->reynoldsFieldNameVec_.begin(), avInfo->reynoldsFieldNameVec_.end(), velocityName) == avInfo->reynoldsFieldNameVec_.end() ) {
@@ -142,6 +144,21 @@ TurbulenceAveragingPostProcessing::load(
           }  
         } 
         
+        if ( avInfo->computeFavreTke_ || avInfo->computeFavreStress_ ) {
+          const std::string velocityName = "velocity";
+          if ( std::find(avInfo->favreFieldNameVec_.begin(), avInfo->favreFieldNameVec_.end(), velocityName) == avInfo->favreFieldNameVec_.end() ) {
+            // not found; add it
+            avInfo->favreFieldNameVec_.push_back(velocityName);
+          }
+          // check for density
+          const std::string densityName = "density";
+          if ( std::find(avInfo->favreFieldNameVec_.begin(), avInfo->favreFieldNameVec_.end(), densityName) == avInfo->favreFieldNameVec_.end() ) {
+            // not found; add it
+            avInfo->favreFieldNameVec_.push_back(velocityName);
+          }
+
+        }
+
         // push back the object
         averageInfoVec_.push_back(avInfo);
       }
@@ -170,10 +187,10 @@ TurbulenceAveragingPostProcessing::setup()
 
     // loop over all target names, extract the part; register the fields
     for ( size_t itarget = 0; itarget < avInfo->targetNames_.size(); ++itarget ) {
-      stk::mesh::Part *targetPart = metaData.get_part(avInfo->targetNames_[itarget]);
+      stk::mesh::Part *targetPart = metaData.get_part(realm_.physics_part_name(avInfo->targetNames_[itarget]));
       if ( NULL == targetPart ) {
         NaluEnv::self().naluOutputP0() << "Trouble with part " << avInfo->targetNames_[itarget] << std::endl;
-        throw std::runtime_error("Sorry, no part name found by the name: " + avInfo->targetNames_[itarget]);
+        throw std::runtime_error("Sorry, no part name found by the name: " + realm_.physics_part_name(avInfo->targetNames_[itarget]));
       }
       else {
         // push back
@@ -184,26 +201,29 @@ TurbulenceAveragingPostProcessing::setup()
       if ( avInfo->computeTke_ ) {
         // hack a name; the name is not tied to the average info name
         const std::string tkeName = "resolved_turbulent_ke";
-        // register and put the field
-        stk::mesh::FieldBase *tkeField 
-          = &(metaData.declare_field< stk::mesh::Field<double, stk::mesh::SimpleArrayTag> >(stk::topology::NODE_RANK, tkeName));
-        stk::mesh::put_field(*tkeField,*targetPart,1);
-        // augment the restart list
-        realm_.augment_restart_variable_list(tkeName);
+        const int sizeOfField = 1;
+        register_field(tkeName, sizeOfField, metaData, targetPart);
+      }
+
+      if ( avInfo->computeFavreTke_ ) {
+        // hack a name; the name is not tied to the average info name
+        const std::string tkeName = "resolved_favre_turbulent_ke";
+        const int sizeOfField = 1;
+        register_field(tkeName, sizeOfField, metaData, targetPart);
       }
 
       // second, register stress
+      const int stressSize = realm_.spatialDimension_ == 3 ? 6 : 3;
       if ( avInfo->computeReynoldsStress_ ) {
         // hack a name; the name is not tied to the average info name
         const std::string stressName = "reynolds_stress";
-        // register and put the field
-        stk::mesh::FieldBase *stressField 
-          = &(metaData.declare_field< stk::mesh::Field<double, stk::mesh::SimpleArrayTag> >(stk::topology::NODE_RANK, stressName));
-        // only output the unique components of the tensor
-        const int stressSize = realm_.spatialDimension_ == 3 ? 6 : 3;
-        stk::mesh::put_field(*stressField, *targetPart, stressSize);
-        // augment the restart list
-        realm_.augment_restart_variable_list(stressName);
+        register_field(stressName, stressSize, metaData, targetPart);
+      }
+
+      if ( avInfo->computeFavreStress_ ) {
+        // hack a name; the name is not tied to the average info name
+        const std::string stressName = "favre_stress";
+        register_field(stressName, stressSize, metaData, targetPart);
       }
 
       // deal with density; always need Reynolds averaged quantity
@@ -211,18 +231,18 @@ TurbulenceAveragingPostProcessing::setup()
       ScalarFieldType *densityReynolds =  &(metaData.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, densityReynoldsName));
       stk::mesh::put_field(*densityReynolds, *targetPart);
       
-      // reynolds
+      // Reynolds
       for ( size_t i = 0; i < avInfo->reynoldsFieldNameVec_.size(); ++i ) {
         const std::string primitiveName = avInfo->reynoldsFieldNameVec_[i];
         const std::string averagedName = primitiveName + "_ra_" + averageBlockName;
-        register_field(primitiveName, averagedName, metaData, targetPart);
+        register_field_from_primitive(primitiveName, averagedName, metaData, targetPart);
       }
       
-      // favre
+      // Favre
       for ( size_t i = 0; i < avInfo->favreFieldNameVec_.size(); ++i ) {
         const std::string primitiveName = avInfo->favreFieldNameVec_[i];
         const std::string averagedName = primitiveName + "_fa_" + averageBlockName;
-        register_field(primitiveName, averagedName, metaData, targetPart);
+        register_field_from_primitive(primitiveName, averagedName, metaData, targetPart);
       }      
     }
 
@@ -235,14 +255,14 @@ TurbulenceAveragingPostProcessing::setup()
     avInfo->reynoldsFieldSizeVec_.push_back(1);
     realm_.augment_restart_variable_list(densityReynoldsName);
     
-    // reynolds
+    // Reynolds
     for ( size_t i = 0; i < avInfo->reynoldsFieldNameVec_.size(); ++i ) {
       const std::string primitiveName = avInfo->reynoldsFieldNameVec_[i];
       const std::string averagedName = primitiveName + "_ra_" + averageBlockName;
       construct_pair(primitiveName, averagedName, avInfo->reynoldsFieldVecPair_, avInfo->reynoldsFieldSizeVec_, metaData);
     }
     
-    // favre
+    // Favre
     for ( size_t i = 0; i < avInfo->favreFieldNameVec_.size(); ++i ) {
       const std::string primitiveName = avInfo->favreFieldNameVec_[i];
       const std::string averagedName = primitiveName + "_fa_" + averageBlockName;
@@ -255,10 +275,10 @@ TurbulenceAveragingPostProcessing::setup()
 }
 
 //--------------------------------------------------------------------------
-//-------- register_field --------------------------------------------------
+//-------- register_field_from_primitive -----------------------------------
 //--------------------------------------------------------------------------
 void
-TurbulenceAveragingPostProcessing::register_field(
+TurbulenceAveragingPostProcessing::register_field_from_primitive(
   const std::string primitiveName,
   const std::string averagedName,
   stk::mesh::MetaData &metaData,
@@ -270,7 +290,7 @@ TurbulenceAveragingPostProcessing::register_field(
   // declare field; put the field and augment restart; need size from the primitive
   stk::mesh::FieldBase *primitiveField = metaData.get_field(stk::topology::NODE_RANK, primitiveName);
 
-  // check for existance and if it is a double
+  // check for existence and if it is a double
   if ( NULL == primitiveField )
     throw std::runtime_error("TurbulenceAveragingPostProcessing::register_field() no primitive by this name: " + primitiveName);
 
@@ -310,12 +330,30 @@ TurbulenceAveragingPostProcessing::construct_pair(
   stk::mesh::FieldBase *primitiveField = metaData.get_field(stk::topology::NODE_RANK, primitiveName);
   stk::mesh::FieldBase *averagedField = metaData.get_field(stk::topology::NODE_RANK, averagedName);
   
-  // the size; gaurenteed to be the same based on the field registration
+  // the size; guaranteed to be the same based on the field registration
   const unsigned fieldSizeAveraged = averagedField->max_size(stk::topology::NODE_RANK);
   fieldSizeVec.push_back(fieldSizeAveraged);
   
   // construct pairs
   fieldVecPair.push_back(std::make_pair(primitiveField, averagedField));
+}
+
+//--------------------------------------------------------------------------
+//-------- register_field --------------------------------------------------
+//--------------------------------------------------------------------------
+void
+TurbulenceAveragingPostProcessing::register_field(
+  const std::string fieldName,
+  const int fieldSize,
+  stk::mesh::MetaData &metaData,
+  stk::mesh::Part *targetPart)
+{
+  // register and put the field
+  stk::mesh::FieldBase *theField
+    = &(metaData.declare_field< stk::mesh::Field<double, stk::mesh::SimpleArrayTag> >(stk::topology::NODE_RANK, fieldName));
+  stk::mesh::put_field(*theField,*targetPart,fieldSize);
+  // augment the restart list
+  realm_.augment_restart_variable_list(fieldName);
 }
 
 //--------------------------------------------------------------------------
@@ -347,9 +385,18 @@ TurbulenceAveragingPostProcessing::review(
     NaluEnv::self().naluOutputP0() << "TKE will be computed; add resolved_turbulent_ke to the Reynolds/Favre block for mean"<< std::endl;
   }
   
+  if ( avInfo->computeFavreTke_ ) {
+     NaluEnv::self().naluOutputP0() << "Favre-TKE will be computed; add resolved_favre_turbulent_ke to the Reynolds/Favre block for mean"<< std::endl;
+   }
+
   if ( avInfo->computeReynoldsStress_ ) {
     NaluEnv::self().naluOutputP0() << "Reynolds Stress will be computed; add reynolds_stress to output"<< std::endl;
   }
+
+  if ( avInfo->computeFavreStress_ ) {
+    NaluEnv::self().naluOutputP0() << "Favre Stress will be computed; add favre_stress to output"<< std::endl;
+  }
+
   NaluEnv::self().naluOutputP0() << "===========================" << std::endl;
 }
 
@@ -429,7 +476,7 @@ TurbulenceAveragingPostProcessing::execute()
         const double rho = density[k];
         const double rhoRA  = densityRA[k];
 
-        // favre
+        // Favre
         for ( size_t iav = 0; iav < favreFieldPairSize; ++iav ) {
           stk::mesh::FieldBase *primitiveFB = avInfo->favreFieldVecPair_[iav].first;
           stk::mesh::FieldBase *averageFB = avInfo->favreFieldVecPair_[iav].second;
@@ -447,84 +494,188 @@ TurbulenceAveragingPostProcessing::execute()
   
     // process tke
     if ( avInfo->computeTke_ ) {
+      compute_tke(true, avInfo->name_, s_all_nodes);
+    }
+    if ( avInfo->computeFavreTke_ ) {
+      compute_tke(false, avInfo->name_, s_all_nodes);
+    }
 
-      const int nDim = realm_.spatialDimension_;
+    // process stress
+    if ( avInfo->computeFavreStress_ ) {
+      compute_favre_stress(avInfo->name_, oldTimeFilter, zeroCurrent, dt, s_all_nodes);
+    }
 
-      const std::string averageBlockName = avInfo->name_;
-      const std::string velocityRAName = "velocity_ra_" + averageBlockName;
-      const std::string resolvedTkeName = "resolved_turbulent_ke";
+    if ( avInfo->computeReynoldsStress_ ) {
+      compute_reynolds_stress(avInfo->name_, oldTimeFilter, zeroCurrent, dt, s_all_nodes);
+    }
+  }
+}
 
-      // extract fields
-      stk::mesh::FieldBase *velocity = metaData.get_field(stk::topology::NODE_RANK, "velocity");
-      stk::mesh::FieldBase *velocityRA = metaData.get_field(stk::topology::NODE_RANK, velocityRAName);
-      stk::mesh::FieldBase *resololvedTke = metaData.get_field(stk::topology::NODE_RANK, resolvedTkeName);
-      
-      stk::mesh::BucketVector const& node_buckets_tke =
-        realm_.get_buckets( stk::topology::NODE_RANK, s_all_nodes );
-      for ( stk::mesh::BucketVector::const_iterator ib = node_buckets_tke.begin();
-            ib != node_buckets_tke.end() ; ++ib ) {
-        stk::mesh::Bucket & b = **ib ;
-        const stk::mesh::Bucket::size_type length   = b.size();
-      
-        // fields
-        const double *uNp1 = (double*)stk::mesh::field_data(*velocity, b);
-        const double *uNp1RA = (double*)stk::mesh::field_data(*velocityRA, b);
-        double *tke = (double*)stk::mesh::field_data(*resololvedTke, b);
-        
-        for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
-          double sum = 0.0;
-          for ( int j = 0; j < nDim; ++j ) {
-            const double uPrime = uNp1[k*nDim+j] - uNp1RA[k*nDim+j];
-            sum += 0.5*uPrime*uPrime;
-          }
-          tke[k] = sum;
+//--------------------------------------------------------------------------
+//-------- compute_tke -----------------------------------------------------
+//--------------------------------------------------------------------------
+void
+TurbulenceAveragingPostProcessing::compute_tke(
+  const bool isReynolds,
+  const std::string &averageBlockName,
+  stk::mesh::Selector s_all_nodes)
+{
+  stk::mesh::MetaData & metaData = realm_.meta_data();
+
+  const int nDim = realm_.spatialDimension_;
+
+  // check for precise set of names
+  const std::string velocityName = isReynolds
+      ? "velocity_ra_" + averageBlockName
+      : "velocity_fa_" + averageBlockName;
+  const std::string resolvedTkeName = isReynolds
+      ? "resolved_turbulent_ke"
+      : "resolved_favre_turbulent_ke";
+
+  // extract fields
+  stk::mesh::FieldBase *velocity = metaData.get_field(stk::topology::NODE_RANK, "velocity");
+  stk::mesh::FieldBase *velocityA = metaData.get_field(stk::topology::NODE_RANK, velocityName);
+  stk::mesh::FieldBase *resololvedTke = metaData.get_field(stk::topology::NODE_RANK, resolvedTkeName);
+
+  stk::mesh::BucketVector const& node_buckets_tke =
+    realm_.get_buckets( stk::topology::NODE_RANK, s_all_nodes );
+  for ( stk::mesh::BucketVector::const_iterator ib = node_buckets_tke.begin();
+        ib != node_buckets_tke.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+    const stk::mesh::Bucket::size_type length   = b.size();
+
+    // fields
+    const double *uNp1 = (double*)stk::mesh::field_data(*velocity, b);
+    const double *uNp1A = (double*)stk::mesh::field_data(*velocityA, b);
+    double *tke = (double*)stk::mesh::field_data(*resololvedTke, b);
+
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+      double sum = 0.0;
+      for ( int j = 0; j < nDim; ++j ) {
+        const double uPrime = uNp1[k*nDim+j] - uNp1A[k*nDim+j];
+        sum += 0.5*uPrime*uPrime;
+      }
+      tke[k] = sum;
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- compute_reynolds_stress -----------------------------------------
+//--------------------------------------------------------------------------
+void
+TurbulenceAveragingPostProcessing::compute_reynolds_stress(
+  const std::string &averageBlockName,
+  const double &oldTimeFilter,
+  const double &zeroCurrent,
+  const double &dt,
+  stk::mesh::Selector s_all_nodes)
+{
+  stk::mesh::MetaData & metaData = realm_.meta_data();
+
+  const int nDim = realm_.spatialDimension_;
+  const int stressSize = realm_.spatialDimension_ == 3 ? 6 : 3;
+
+  const std::string velocityAName = "velocity_ra_" + averageBlockName;
+  const std::string densityAName = "density_ra_" + averageBlockName;
+  const std::string stressName = "reynolds_stress";
+
+  // extract fields
+  stk::mesh::FieldBase *velocity = metaData.get_field(stk::topology::NODE_RANK, "velocity");
+  stk::mesh::FieldBase *velocityA = metaData.get_field(stk::topology::NODE_RANK, velocityAName);
+  stk::mesh::FieldBase *stressA = metaData.get_field(stk::topology::NODE_RANK, stressName);
+
+  stk::mesh::BucketVector const& node_buckets_stress =
+    realm_.get_buckets( stk::topology::NODE_RANK, s_all_nodes );
+  for ( stk::mesh::BucketVector::const_iterator ib = node_buckets_stress.begin();
+        ib != node_buckets_stress.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+    const stk::mesh::Bucket::size_type length   = b.size();
+
+    // fields
+    const double *uNp1 = (double*)stk::mesh::field_data(*velocity, b);
+    const double *uNp1A = (double*)stk::mesh::field_data(*velocityA, b);
+    double *stress = (double*)stk::mesh::field_data(*stressA, b);
+
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+
+      // stress is symmetric, so only save off 6 or 3 components
+      int componentCount = 0;
+      for ( int i = 0; i < nDim; ++i ) {
+        const double ui = uNp1[k*nDim+i];
+        const double uiA = uNp1A[k*nDim+i];
+        for ( int j = i; j < nDim; ++j ) {
+          const int component = componentCount;
+          const double uj = uNp1[k*nDim+j];
+          const double ujA = uNp1A[k*nDim+j];
+          const double newStress = (stress[k*stressSize+component]*oldTimeFilter*zeroCurrent + ui*uj*dt - uiA*ujA*dt)/currentTimeFilter_;
+          stress[k*stressSize+component] = newStress;
+          componentCount++;
         }
       }
-    } 
-  
-    // process stress
-    if ( avInfo->computeReynoldsStress_ ) {
+    }
+  }
+}
 
-      const int nDim = realm_.spatialDimension_;
-      const int stressSize = realm_.spatialDimension_ == 3 ? 6 : 3;
-      
-      const std::string averageBlockName = avInfo->name_;
-      const std::string velocityRAName = "velocity_ra_" + averageBlockName;
-      const std::string stressName = "reynolds_stress";
+//--------------------------------------------------------------------------
+//-------- compute_favre_stress --------------------------------------------
+//--------------------------------------------------------------------------
+void
+TurbulenceAveragingPostProcessing::compute_favre_stress(
+  const std::string &averageBlockName,
+  const double &oldTimeFilter,
+  const double &zeroCurrent,
+  const double &dt,
+  stk::mesh::Selector s_all_nodes)
+{
+  stk::mesh::MetaData & metaData = realm_.meta_data();
 
-      // extract fields
-      stk::mesh::FieldBase *velocity = metaData.get_field(stk::topology::NODE_RANK, "velocity");
-      stk::mesh::FieldBase *velocityRA = metaData.get_field(stk::topology::NODE_RANK, velocityRAName);
-      stk::mesh::FieldBase *reynoldsStress = metaData.get_field(stk::topology::NODE_RANK, stressName);
+  const int nDim = realm_.spatialDimension_;
+  const int stressSize = realm_.spatialDimension_ == 3 ? 6 : 3;
 
-      stk::mesh::BucketVector const& node_buckets_stress =
-        realm_.get_buckets( stk::topology::NODE_RANK, s_all_nodes );
-      for ( stk::mesh::BucketVector::const_iterator ib = node_buckets_stress.begin();
-            ib != node_buckets_stress.end() ; ++ib ) {
-        stk::mesh::Bucket & b = **ib ;
-        const stk::mesh::Bucket::size_type length   = b.size();   
+  const std::string velocityAName = "velocity_fa_" + averageBlockName;
+  const std::string densityAName = "density_ra_" + averageBlockName;
+  const std::string stressName = "favre_stress";
 
-        // fields
-        const double *uNp1 = (double*)stk::mesh::field_data(*velocity, b);
-        const double *uNp1RA = (double*)stk::mesh::field_data(*velocityRA, b);
-        double *stress = (double*)stk::mesh::field_data(*reynoldsStress, b);
-        
-        for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
-          
-          // stress is symmetric, so only save off 6 or 3 components
-          int componentCount = 0;
-          for ( int i = 0; i < nDim; ++i ) {
-            const double ui = uNp1[k*nDim+i];
-            const double uiRA = uNp1RA[k*nDim+i];
-            for ( int j = i; j < nDim; ++j ) {
-              const int component = componentCount;
-              const double uj = uNp1[k*nDim+j];
-              const double ujRA = uNp1RA[k*nDim+j];
-              const double newStress = (stress[k*stressSize+component]*oldTimeFilter*zeroCurrent + ui*uj*dt - uiRA*ujRA*dt)/currentTimeFilter_;
-              stress[k*stressSize+component] = newStress;
-              componentCount++;
-            }
-          }
+  // extract fields
+  stk::mesh::FieldBase *velocity = metaData.get_field(stk::topology::NODE_RANK, "velocity");
+  stk::mesh::FieldBase *density = metaData.get_field(stk::topology::NODE_RANK, "density");
+  stk::mesh::FieldBase *densityA = metaData.get_field(stk::topology::NODE_RANK, densityAName);
+  stk::mesh::FieldBase *velocityA = metaData.get_field(stk::topology::NODE_RANK, velocityAName);
+  stk::mesh::FieldBase *stressA = metaData.get_field(stk::topology::NODE_RANK, stressName);
+
+  stk::mesh::BucketVector const& node_buckets_stress =
+    realm_.get_buckets( stk::topology::NODE_RANK, s_all_nodes );
+  for ( stk::mesh::BucketVector::const_iterator ib = node_buckets_stress.begin();
+        ib != node_buckets_stress.end() ; ++ib ) {
+    stk::mesh::Bucket & b = **ib ;
+    const stk::mesh::Bucket::size_type length   = b.size();
+
+    // fields
+    const double *uNp1 = (double*)stk::mesh::field_data(*velocity, b);
+    const double *uNp1A = (double*)stk::mesh::field_data(*velocityA, b);
+    const double *rho = (double*)stk::mesh::field_data(*density, b);
+    const double *rhoA = (double*)stk::mesh::field_data(*densityA, b);
+    double *stress = (double*)stk::mesh::field_data(*stressA, b);
+
+    for ( stk::mesh::Bucket::size_type k = 0 ; k < length ; ++k ) {
+
+      // save off density
+      const double rhok = rho[k];
+      const double rhoAk = rhoA[k];
+
+      // stress is symmetric, so only save off 6 or 3 components
+      int componentCount = 0;
+      for ( int i = 0; i < nDim; ++i ) {
+        const double ui = uNp1[k*nDim+i];
+        const double uiA = uNp1A[k*nDim+i];
+        for ( int j = i; j < nDim; ++j ) {
+          const int component = componentCount;
+          const double uj = uNp1[k*nDim+j];
+          const double ujA = uNp1A[k*nDim+j];
+          const double newStress = (stress[k*stressSize+component]*oldTimeFilter*zeroCurrent + (ui*uj*rhok/rhoAk - uiA*ujA)*dt)/currentTimeFilter_;
+          stress[k*stressSize+component] = newStress;
+          componentCount++;
         }
       }
     }

--- a/src/element_promotion/ElementCondenser.C
+++ b/src/element_promotion/ElementCondenser.C
@@ -1,0 +1,175 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporatlion.                                   */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+#include <element_promotion/ElementCondenser.h>
+
+#include <element_promotion/ElementDescription.h>
+#include <element_promotion/QuadratureRule.h>
+#include <NaluEnv.h>
+
+#include <stk_util/environment/ReportHandler.hpp>
+#include <Teuchos_RCP.hpp>
+
+#include <tuple>
+
+namespace sierra {
+namespace nalu {
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// ElementReducer - Condenses out interior degrees of freedom for
+// linear elliptic problems (i.e. the ppe)
+//==========================================================================
+ElementCondenser::ElementCondenser(const ElementDescription& elem)
+: blas_(Teuchos::BLAS<int,double>()),
+  lapack_(Teuchos::LAPACK<int,double>())
+{
+  ne_ = elem.nodesPerElement;
+  ni_ = std::pow(elem.polyOrder-1, elem.dimension);
+  nb_ = ne_ - ni_;
+
+  lhsBB_.resize(nb_ * nb_);
+  lhsBI_.resize(nb_ * ni_);
+  lhsIB_.resize(ni_ * nb_);
+  lhsII_.resize(ni_ * ni_);
+  ipiv_.resize(ni_ * ni_);
+  rhsI_.resize(ni_);
+}
+//--------------------------------------------------------------------------
+template <typename Scalar>
+void mat_chunk(
+  const Scalar* mat,
+  int nrows,
+  Scalar* chunk,
+  int istart,
+  int jstart,
+  int iend,
+  int jend)
+{
+  // copies matrix section of column major square matrix into contiguous, row-major submatrix
+  ThrowAssert(istart >= 0 && istart < iend);
+  ThrowAssert(jstart >= 0 && jstart < jend);
+  ThrowAssert(iend <= nrows);
+  ThrowAssert(jend <= nrows);
+
+  int jj = 0;
+  for (int j = jstart; j < jend; ++j) {
+    for (int i = istart; i < iend; ++i, ++jj) {
+      chunk[jj] = mat[i*nrows + j];
+    }
+  }
+}
+//--------------------------------------------------------------------------
+void
+ElementCondenser::condense(
+  double* lhs, const double* rhs,
+  double* b_lhs, double* b_rhs)
+{
+  // Computes the condensed left/right-hand sides for the high-order matrices
+  // Split matrix into four contiguous chunks assuming a column-major "lhs"
+
+  // NOTE: The nodes are numbered such that the nodes to be condensed out are
+  // the last (p-1)^dim nodes in the matrix
+
+  // boundary-boundary interaction
+  mat_chunk(lhs, ne_,
+    b_lhs,
+    0, 0,
+    nb_, nb_
+  );
+
+  // boundary-interior interaction
+  mat_chunk(lhs, ne_,
+    lhsBI_.data(),
+    0, nb_,
+    nb_, ne_
+  );
+
+  // interior-boundary interaction
+  mat_chunk(lhs, ne_,
+    lhsIB_.data(),
+    nb_, 0,
+    ne_, nb_
+  );
+
+  // interior-interior interaction
+  mat_chunk(lhs, ne_,
+    lhsII_.data(),
+    nb_, nb_,
+    ne_, ne_
+  );
+
+  // boundary terms for rhs vector
+  for (int j = 0; j < nb_; ++j) {
+    b_rhs[j] = rhs[j];
+  }
+
+  // interior terms for rhs vector
+  int jj = 0;
+  for (int j = nb_; j < ne_; ++j, ++jj) {
+    rhsI_[jj] = rhs[j];
+  }
+
+  // compute LU decomposition of lhsII
+  int info = 0;
+  lapack_.GETRF(ni_,ni_,lhsII_.data(), ni_, ipiv_.data(), &info);
+  ThrowAssert(info == 0);
+
+  // solve for the effect of the interior on the boundary matrix L_II^-1 L_IB
+  lapack_.GETRS('N',ni_,nb_,lhsII_.data(), ni_, ipiv_.data(), lhsIB_.data(), ni_, &info);
+  ThrowAssert(info == 0);
+
+  // apply modification to boundary-boundary matrix (L_BB - L_BI L_II^-1 L_IB)
+  blas_.GEMM(Teuchos::NO_TRANS, Teuchos::NO_TRANS,
+    nb_, nb_, ni_,
+    -1.0,
+    lhsBI_.data(), nb_,
+    lhsIB_.data(), ni_,
+    +1.0,
+    b_lhs, nb_
+  );
+
+  // compute interior effect on boundary rhs vector  L_II^-1 f_I
+  lapack_.GETRS('N', ni_, 1, lhsII_.data(), ni_, ipiv_.data(), rhsI_.data(), ni_, &info);
+  ThrowAssert(info == 0);
+
+  // apply f_b - L_BI L_II^-1 f_I
+  blas_.GEMV(Teuchos::NO_TRANS,
+    nb_, ni_,
+    -1.0,
+    lhsBI_.data(), nb_,
+    rhsI_.data(), 1,
+    +1.0,
+    b_rhs, 1
+  );
+}
+//--------------------------------------------------------------------------
+void ElementCondenser::compute_interior_update(
+  double* lhs, const double* rhs,
+  const double* boundary_values, double* delta_interior_values)
+{
+  // Computes an update to the interior values given the updated rhs vector
+  // and the elemental linear system
+  mat_chunk(lhs, ne_,
+    lhsII_.data(),
+    nb_, nb_,
+    ne_, ne_
+  );
+
+  int jj = 0;
+  for (int j = nb_; j < ne_; ++j, ++jj) {
+    delta_interior_values[jj] = rhs[j];
+  }
+
+  // solve for update L_II^-1 rhs_I
+  int info = 0;
+  lapack_.GESV(ni_, 1, lhsII_.data(), ni_, ipiv_.data(), delta_interior_values, ni_, &info);
+  ThrowAssert(info == 0);
+}
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/element_promotion/MasterElement.C
+++ b/src/element_promotion/MasterElement.C
@@ -1,0 +1,46 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include <element_promotion/MasterElement.h>
+
+namespace sierra{
+namespace naluUnit{
+
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+MasterElement::MasterElement()
+  : nDim_(0),
+    nodesPerElement_(0),
+    numIntPoints_(0),
+    scaleToStandardIsoFac_(1.0)
+{
+  // nothing else
+}
+
+//--------------------------------------------------------------------------
+//-------- destructor ------------------------------------------------------
+//--------------------------------------------------------------------------
+MasterElement::~MasterElement()
+{
+  // does nothing
+}
+
+//--------------------------------------------------------------------------
+//-------- isoparametric_mapping -------------------------------------------
+//--------------------------------------------------------------------------
+double
+MasterElement::isoparametric_mapping( 
+  const double b,
+  const double a,
+  const double xi) const
+{
+  return xi*(b-a)/2.0 +(a+b)/2.0;
+}
+
+}  // namespace naluUnit
+} // namespace sierra

--- a/src/element_promotion/PromoteElement.C
+++ b/src/element_promotion/PromoteElement.C
@@ -50,7 +50,9 @@ PromoteElement::PromoteElement(ElementDescription& elemDescription)
   nodesPerElement_(elemDescription.nodesPerElement),
   dimension_(elemDescription.dimension)
 {
- //do nothing
+ ThrowRequire(dimension_ == 2 || dimension_ == 3);
+ ThrowRequire(elemDescription_.polyOrder > 0);
+ ThrowRequire(nodesPerElement_ >= std::pow(2,dimension_));
 }
 //--------------------------------------------------------------------------
 void
@@ -62,26 +64,19 @@ PromoteElement::promote_elements(
   ThrowRequireMsg(mesh.in_modifiable_state(),
     "Mesh must be in a modifiable state for element promotion");
 
-  // holds the original elements and original nodes
-  baseParts_ = baseParts;
-
-  // holds only the new nodes.  Naming convention for new parts has to follow
-  // the "promotion_suffix()" convention
-  promotedParts_ = promote_part_vector(baseParts);
-  ThrowAssertMsg(part_vector_is_valid(promotedParts_),
-    "One or more promoted parts were not declared");
+  ThrowRequire(check_parts_for_promotion(baseParts));
 
   auto basePartSelector = stk::mesh::selectUnion(baseParts);
   auto nodeRequests = create_child_node_requests(elemDescription_, mesh, basePartSelector);
   determine_child_ordinals(elemDescription_,mesh, nodeRequests);
-  batch_create_child_nodes(elemDescription_, mesh, nodeRequests, baseParts);
 
-  ElemRelationsMap elemNodeMap;
-  populate_elem_node_relations(elemDescription_, mesh, basePartSelector, nodeRequests, elemNodeMap);
-  create_elements(mesh, baseParts, elemNodeMap);
+  auto& rootNodePart =
+      mesh.mesh_meta_data().get_cell_topology_root_part(stk::mesh::get_cell_topology(stk::topology::NODE));
 
-  auto baseAndSuperElemParts = append_super_elems_to_part_vector(baseParts);
-  populate_boundary_elem_node_relations(mesh, baseAndSuperElemParts);
+  batch_create_child_nodes(elemDescription_, mesh, nodeRequests, rootNodePart);
+
+  auto elemNodeMap = make_elem_node_relations_map(elemDescription_, mesh, basePartSelector, nodeRequests);
+  populate_upward_relations_map(elemDescription_, mesh, basePartSelector, nodeRequests);
 
   if (dimension_ == 2) {
     set_new_node_coords<2>(coordinates, elemDescription_, mesh, nodeRequests, elemNodeMap);
@@ -89,6 +84,9 @@ PromoteElement::promote_elements(
   else {
     set_new_node_coords<3>(coordinates, elemDescription_, mesh, nodeRequests, elemNodeMap);
   }
+
+  create_elements(mesh, baseParts, elemNodeMap);
+  create_boundary_face_elements(mesh, baseParts);
 }
 //--------------------------------------------------------------------------
 PromoteElement::NodeRequests
@@ -168,7 +166,7 @@ PromoteElement::determine_child_ordinals(
       const auto& ordinals = request.childOrdinalsForElem_[elemNumber];
       const auto& canonicalOrdinals = elemDescription.addedConnectivities.at(ordinals);
 
-      request.reorderedChildOrdinalsForElem_[elemNumber] = reorder_ordinals<size_t>(
+      request.reorderedChildOrdinalsForElem_[elemNumber] = reorder_ordinals(
         ordinals,
         unsortedOrdinals,
         canonicalOrdinals,
@@ -184,7 +182,7 @@ PromoteElement::batch_create_child_nodes(
   const ElementDescription& elemDescription,
   stk::mesh::BulkData& mesh,
   NodeRequests& requests,
-  const stk::mesh::PartVector& node_parts) const
+  stk::mesh::Part& rootNodePart) const
 {
   size_t num_nodes_requested = count_requested_nodes(requests);
   std::vector<stk::mesh::EntityId> available_node_ids(num_nodes_requested);
@@ -206,8 +204,7 @@ PromoteElement::batch_create_child_nodes(
   }
 
   for (auto& request : requests) {
-    auto meshPartsForChildNodes = request.mesh_parts_for_child_nodes(mesh, node_parts);
-    request.set_node_entity_for_request(mesh, meshPartsForChildNodes);
+    request.set_node_entity_for_request(mesh, rootNodePart);
   }
 }
 //--------------------------------------------------------------------------
@@ -227,17 +224,20 @@ PromoteElement::parallel_communicate_ids(
     for (const auto& request : requests) {
       for (auto other_proc : request.sharingProcs_) {
         if (other_proc != mesh.parallel_rank()) {
-          const auto& request_parents = request.unsortedParentIds_;
-          const auto numChildren = request.num_children();
-          comm_spec.send_buffer(other_proc).pack(request.num_parents());
+          const size_t numParents = request.num_parents();
+          comm_spec.send_buffer(other_proc).pack(numParents);
+
+          const size_t numChildren = request.num_children();
           comm_spec.send_buffer(other_proc).pack(numChildren);
-          for (auto parentId : request_parents) {
+
+          const std::vector<stk::mesh::EntityId>& request_parents = request.unsortedParentIds_;
+          for (stk::mesh::EntityId parentId : request_parents) {
             comm_spec.send_buffer(other_proc).pack(parentId);
           }
 
           for (unsigned j = 0; j < numChildren; ++j) {
-            comm_spec.send_buffer(other_proc).pack(
-              request.suggested_node_id(j));
+            const stk::mesh::EntityId suggestedNodeId = request.suggested_node_id(j);
+            comm_spec.send_buffer(other_proc).pack(suggestedNodeId);
           }
         }
       }
@@ -255,15 +255,14 @@ PromoteElement::parallel_communicate_ids(
   for (int i = 0; i < mesh.parallel_size(); ++i) {
     if (i != mesh.parallel_rank()) {
       while (comm_spec.recv_buffer(i).remaining() != 0) {
+        size_t numParents;
+        comm_spec.recv_buffer(i).unpack(numParents);
 
-        size_t num_parents;
-        size_t num_children;
-        stk::mesh::EntityId suggested_node_id;
-        comm_spec.recv_buffer(i).unpack(num_parents);
-        comm_spec.recv_buffer(i).unpack(num_children);
-        std::vector<stk::mesh::EntityId> parentIds(num_parents);
+        size_t numChildren;
+        comm_spec.recv_buffer(i).unpack(numChildren);
 
-        for (auto& parentId : parentIds) {
+        std::vector<stk::mesh::EntityId> parentIds(numParents);
+        for (stk::mesh::EntityId& parentId : parentIds) {
           comm_spec.recv_buffer(i).unpack(parentId);
         }
 
@@ -274,7 +273,7 @@ PromoteElement::parallel_communicate_ids(
 
         std::vector<size_t> indices;
         if (hasParents) {
-          indices.resize(num_children);
+          indices.resize(numChildren);
           std::iota(indices.begin(), indices.end(), 0);
 
           // nodes are compared against a single set of parent ordinals
@@ -286,7 +285,7 @@ PromoteElement::parallel_communicate_ids(
           // by sending over the reference parentIds and then match indices with the ordinals to ensure
           // consistent global node ids in parallel
 
-          if (num_children == numAddedNodes1D*numAddedNodes1D && dimension_ == 3) {
+          if (elemDescription.dimension == 3 && numChildren == numAddedNodes1D*numAddedNodes1D) {
             auto request = *iter;
             unsigned elemNumber = 0u;
             unsigned numParents1D = 2u;
@@ -302,7 +301,7 @@ PromoteElement::parallel_communicate_ids(
             const auto& canonicalOrdinals =
                 elemDescription.addedConnectivities.at(request.childOrdinalsForElem_[elemNumber]);
 
-            indices = reorder_ordinals<size_t>(
+            indices = reorder_ordinals(
               indices,
               childOrdinals,
               canonicalOrdinals,
@@ -312,8 +311,9 @@ PromoteElement::parallel_communicate_ids(
           }
         }
 
-        for (unsigned j = 0; j < num_children; ++j) {
+        for (unsigned j = 0; j < numChildren; ++j) {
           //always unpack to keep the correct place in buffer
+          stk::mesh::EntityId suggested_node_id;
           comm_spec.recv_buffer(i).unpack(suggested_node_id);
 
           // Add a proc_id pair between coincident shared nodes
@@ -326,34 +326,18 @@ PromoteElement::parallel_communicate_ids(
   }
 }
 //--------------------------------------------------------------------------
-void
-PromoteElement::populate_elem_node_relations(
+PromoteElement::ElemRelationsMap
+PromoteElement::make_elem_node_relations_map(
   const ElementDescription& elemDescription,
-  stk::mesh::BulkData& mesh,
-  const stk::mesh::Selector& selector,
-  const NodeRequests& requests,
-  ElemRelationsMap& elemNodeMap)
-{
-
-  const stk::mesh::BucketVector& elem_buckets = mesh.get_buckets(
-    stk::topology::ELEM_RANK, selector);
-
-  elemNodeMap.reserve(count_entities(elem_buckets));
-  nodeElemMap_.reserve(count_requested_nodes(requests));
-
-  populate_original_elem_node_relations(mesh, selector, requests, elemNodeMap);
-  populate_new_elem_node_relations(requests,elemNodeMap);
-}
-//--------------------------------------------------------------------------
-void
-PromoteElement::populate_original_elem_node_relations(
   const stk::mesh::BulkData& mesh,
   const stk::mesh::Selector& selector,
-  const NodeRequests& requests,
-  ElemRelationsMap& elemNodeMap)
+  const NodeRequests& requests) const
 {
   const stk::mesh::BucketVector& elem_buckets = mesh.get_buckets(
     stk::topology::ELEM_RANK, selector);
+
+  ElemRelationsMap elemNodeMap;
+  elemNodeMap.reserve(count_entities(elem_buckets));
 
   // initialize base downward relationships
   for (const auto* ib : elem_buckets) {
@@ -362,12 +346,43 @@ PromoteElement::populate_original_elem_node_relations(
     for (stk::mesh::Bucket::size_type k = 0; k < length; ++k) {
       const stk::mesh::Entity elem = b[k];
       const stk::mesh::Entity* nodes = b.begin_nodes(k);
-      elemNodeMap.insert({elem, std::vector<stk::mesh::Entity>(nodesPerElement_) });
+      elemNodeMap.insert({elem, std::vector<stk::mesh::Entity>(elemDescription.nodesPerElement) });
       for (size_t j = 0; j < b.num_nodes(k); ++j) {
         elemNodeMap[elem][j] = nodes[j];
       }
     }
   }
+
+  for (const auto& request : requests) {
+    unsigned numShared = request.sharedElems_.size();
+    for (unsigned elemNumber = 0; elemNumber < numShared; ++elemNumber) {
+      auto sharedElem = request.sharedElems_[elemNumber];
+      auto& ordinals = request.reorderedChildOrdinalsForElem_[elemNumber];
+
+      // Place the newly created nodes in the connectivity map depending on
+      // the assigned ordinal for each element shared by the face
+      for (unsigned j = 0; j < request.num_children(); ++j) {
+        elemNodeMap.at(sharedElem)[ordinals[j]] = request.children_[j];
+      }
+    }
+  }
+  return elemNodeMap;
+}
+//--------------------------------------------------------------------------
+void
+PromoteElement::populate_upward_relations_map(
+  const ElementDescription& elemDescription,
+  const stk::mesh::BulkData& mesh,
+  const stk::mesh::Selector& selector,
+  const NodeRequests& requests)
+{
+  /*
+   * FIXME(rcknaus): since the base nodes are connected to both the original elements
+   * and the super-elements, the stk begin_elements(node) call returns both the base
+   * and promoted elements for the original nodes of the mesh.  I could get around this
+   * either by destroying the node-to-base-element relation or by creating copy nodes
+   * of 4 or 8 nodes of the base element in addition to creating the new nodes
+   */
 
   const stk::mesh::BucketVector& node_buckets = mesh.get_buckets(
     stk::topology::NODE_RANK, selector);
@@ -386,27 +401,8 @@ PromoteElement::populate_original_elem_node_relations(
       }
     }
   }
-}
-//--------------------------------------------------------------------------
-void
-PromoteElement::populate_new_elem_node_relations(
-  const NodeRequests& requests,
-  ElemRelationsMap& elemNodeMap)
-{
+
   for (const auto& request : requests) {
-    unsigned numShared = request.sharedElems_.size();
-    for (unsigned elemNumber = 0; elemNumber < numShared; ++elemNumber) {
-      auto sharedElem = request.sharedElems_[elemNumber];
-      auto& ordinals = request.reorderedChildOrdinalsForElem_[elemNumber];
-
-      // Place the newly created nodes in the connectivity map depending on
-      // the assigned ordinal for each element shared by the face
-      for (unsigned j = 0; j < request.num_children(); ++j) {
-        elemNodeMap.at(sharedElem)[ordinals[j]] = request.children_[j];
-      }
-    }
-
-    // Save the upward connectivity for the new nodes as well
     for (const auto child : request.children_) {
       nodeElemMap_.insert({ child, request.sharedElems_ });
     }
@@ -419,9 +415,8 @@ PromoteElement::create_elements(
   const stk::mesh::PartVector& baseParts,
   ElemRelationsMap& elemNodeMap) const
 {
-  ThrowAssert(check_elem_node_relations(mesh, elemNodeMap));
-
   auto baseElemParts = base_elem_parts(baseParts);
+
   // Generate all new ids up front
   const auto numNewElem = count_entities(mesh.get_buckets(
     stk::topology::ELEM_RANK,
@@ -446,12 +441,10 @@ PromoteElement::create_elements(
     for (const auto* ib : elem_buckets) {
       const stk::mesh::Bucket& b = *ib;
       for (size_t k = 0; k < b.size(); ++k) {
-        const std::vector<stk::mesh::Entity>& nodes = elemNodeMap.at(b[k]);
-        std::transform(nodes.begin(), nodes.end(), connectedNodeIds.begin(),
-          [&mesh] (stk::mesh::Entity e) {
-            return mesh.identifier(e);
-          }
-        );
+        const std::vector<stk::mesh::Entity>& connectedNodes = elemNodeMap.at(b[k]);
+        for (unsigned j = 0; j < connectedNodes.size(); ++j) {
+          connectedNodeIds[j] = mesh.identifier(connectedNodes[j]);
+        }
 
         stk::mesh::declare_element(
           mesh,
@@ -463,40 +456,6 @@ PromoteElement::create_elements(
       }
     }
   }
-}
-//--------------------------------------------------------------------------
-bool
-PromoteElement::check_elem_node_relations(
-  const stk::mesh::BulkData& mesh,
-  ElemRelationsMap& elemNodeMap) const
-{
-  if (elemNodeMap.empty()) {
-    return false;
-  }
-
-  if (nodeElemMap_.empty()) {
-    return false;
-  }
-
-  for (const auto& elemNodePair : elemNodeMap) {
-    for (const auto& node : elemNodePair.second) {
-      if (!(mesh.is_valid(node))) {
-        return false;
-      }
-    }
-  }
-
-  for (const auto& nodeElemPair : nodeElemMap_) {
-    if (nodeElemPair.second.size() < 1) {
-      return false;
-    }
-    for (const auto& elem : nodeElemPair.second) {
-      if (!(mesh.is_valid(elem))) {
-        return false;
-      }
-    }
-  }
-  return true;
 }
 //--------------------------------------------------------------------------
 template<unsigned embedding_dimension> void
@@ -681,24 +640,24 @@ PromoteElement::reorder_ordinals(
   // e.g., a "reversed edge" has its ordinals reversed.
 
   std::vector<T> reorderedOrdinals;
-  if (parents_are_reversed<T>(unsortedOrdinals, canonicalOrdinals)) {
+  if (parents_are_reversed(unsortedOrdinals, canonicalOrdinals)) {
     reorderedOrdinals = ordinals;
     std::reverse(reorderedOrdinals.begin(), reorderedOrdinals.end());
     if(unsortedOrdinals.size() == numParents1D*numParents1D) {
-      reorderedOrdinals = flip_x<T>(reorderedOrdinals, numAddedNodes1D);
+      reorderedOrdinals = flip_x(reorderedOrdinals, numAddedNodes1D);
     }
   }
-  else if (parents_are_flipped_x<T>(unsortedOrdinals, canonicalOrdinals, numParents1D)) {
-    reorderedOrdinals = flip_x<T>(ordinals,numAddedNodes1D);
+  else if (parents_are_flipped_x(unsortedOrdinals, canonicalOrdinals, numParents1D)) {
+    reorderedOrdinals = flip_x(ordinals,numAddedNodes1D);
   }
-  else if (parents_are_flipped_y<T>(unsortedOrdinals, canonicalOrdinals, numParents1D)) {
-    reorderedOrdinals = flip_y<T>(ordinals,numAddedNodes1D);
+  else if (parents_are_flipped_y(unsortedOrdinals, canonicalOrdinals, numParents1D)) {
+    reorderedOrdinals = flip_y(ordinals,numAddedNodes1D);
   }
-  else if (should_transpose<T>(unsortedOrdinals, canonicalOrdinals)) {
-    reorderedOrdinals = transpose_ordinals<T>(ordinals,numAddedNodes1D);
+  else if (should_transpose(unsortedOrdinals, canonicalOrdinals)) {
+    reorderedOrdinals = transpose_ordinals(ordinals,numAddedNodes1D);
   }
-  else if (should_invert<T>(unsortedOrdinals, canonicalOrdinals)) {
-    reorderedOrdinals = invert_ordinals_yx<T>(ordinals,numAddedNodes1D);
+  else if (should_invert(unsortedOrdinals, canonicalOrdinals)) {
+    reorderedOrdinals = invert_ordinals_yx(ordinals,numAddedNodes1D);
   }
   else {
     // If all of the other checks fail, then the parent ordinals should be in
@@ -722,56 +681,74 @@ PromoteElement::count_requested_nodes(const NodeRequests& requests) const
 }
 //--------------------------------------------------------------------------
 void
-PromoteElement::populate_boundary_elem_node_relations(
-  const stk::mesh::BulkData& mesh,
-  const stk::mesh::PartVector& mesh_parts)
+PromoteElement::create_boundary_face_elements(
+  stk::mesh::BulkData& mesh,
+  const stk::mesh::PartVector& mesh_parts) const
 {
-  // Generates connectivity at exposed faces for the super elements (which lack that information)
+  // Generates "superfaces" / "superedges" at for boundary elements
 
-  const auto superElemParts = only_super_elem_parts(mesh_parts);
-  ThrowRequireMsg(part_vector_is_valid(superElemParts), "No super element part in part vector!");
+  // map an exposed face of the base mesh to the superelement to which we
+  // want to attach the corresponding superface
+  auto exposedFaceToSuperElemMap =
+      make_exposed_face_to_super_elem_map(elemDescription_, mesh, base_elem_parts(mesh_parts));
 
-  populate_exposed_face_to_super_elem_map(elemDescription_, mesh, mesh_parts, superElemParts);
-
-  auto rank = (dimension_ == 2) ? stk::topology::EDGE_RANK : stk::topology::FACE_RANK;
-
-  const stk::mesh::BucketVector& boundary_buckets = mesh.get_buckets(
-    rank, stk::mesh::selectUnion(mesh_parts)
+  auto side_rank = mesh.mesh_meta_data().side_rank();
+  const auto numNewFace = count_entities(mesh.get_buckets(
+    side_rank,
+    stk::mesh::selectUnion(mesh_parts))
   );
 
-  auto nodes1D = elemDescription_.nodes1D;
-  std::vector<stk::mesh::Entity> faceNodes(std::pow(nodes1D,dimension_-1));
-  for (const auto* ib : boundary_buckets) {
-    const stk::mesh::Bucket& b = *ib;
-    const stk::mesh::Bucket::size_type length = b.size();
+  // allot new face-ranked ids for the superface
+  std::vector<stk::mesh::EntityId> availableFaceIds(numNewFace);
+  mesh.generate_new_ids(side_rank, numNewFace, availableFaceIds);
 
-    for (stk::mesh::Bucket::size_type k = 0; k < length; ++k) {
-      const auto face = b[k];
-      stk::mesh::Entity superElem = exposedFaceToSuperElemMap_.at(face)[0];
+  // declare super face copies for each base face element
+  size_t faceIdIndex = 0;
+  for (const auto* ipart : mesh_parts) {
+    for (const stk::mesh::Part* subset : ipart->subsets()) {
+      if ( subset->topology().rank() == side_rank
+       && !subset->topology().is_superface()
+       && !subset->topology().is_superedge()) {
+        auto* superFacePart =
+            super_subset_part(*subset, elemDescription_.nodesPerElement, elemDescription_.nodesPerFace);
+        ThrowRequire(superFacePart  != nullptr);
 
-      const auto* face_elem_ords = mesh.begin_element_ordinals(face);
-      const unsigned face_ordinal = face_elem_ords[0];
-      const auto& elem_node_rels = mesh.begin_nodes(superElem);
-      const auto& nodeOrdinalsForFace = elemDescription_.faceNodeMap[face_ordinal];
+        const auto& buckets = mesh.get_buckets(side_rank, *subset);
+        for (const auto* ib : buckets) {
+          const stk::mesh::Bucket& b = *ib;
+          const auto length = b.size();
 
-      if (dimension_ == 2) {
-        for (unsigned j = 0; j < nodes1D; ++j) {
-          int ordinal = elemDescription_.tensor_product_node_map_bc(j);
-          faceNodes[ordinal] = elem_node_rels[nodeOrdinalsForFace[j]];
-        }
-      }
-      else {
-        for (unsigned j = 0; j < nodes1D; ++j) {
-          for (unsigned i = 0; i < nodes1D; ++i) {
-            int ordinal = elemDescription_.tensor_product_node_map_bc(i,j);
-            faceNodes[ordinal] = elem_node_rels[nodeOrdinalsForFace[i+nodes1D*j]];
+          for (stk::mesh::Bucket::size_type k = 0; k < length; ++k) {
+            const auto face = b[k];
+
+            // create the super
+            stk::mesh::Entity superFace =
+                mesh.declare_entity(side_rank, availableFaceIds[faceIdIndex], *superFacePart);
+
+            // get super element associated with base element face
+            const auto superElem = exposedFaceToSuperElemMap.at(face);
+
+            // get nodes for that element
+            const auto* elem_node_rels = mesh.begin_nodes(superElem);
+
+            ThrowAssert(mesh.num_elements(face) == 1);
+
+            // get the ordinal of the face
+            const auto face_ordinal = mesh.begin_element_ordinals(face)[0];
+
+            // method to return the node ordinals associated with an element's face
+            const auto* ordinals = elemDescription_.side_ordinals_for_face(face_ordinal);
+
+            // attach nodes to the new face
+            for (unsigned j = 0; j < elemDescription_.nodesPerFace; ++j) {
+              mesh.declare_relation(superFace, elem_node_rels[ordinals[j]], j);
+            }
+
+            // attach the face to its parent element
+            mesh.declare_relation(superElem, superFace, face_ordinal);
+            ++faceIdIndex;
           }
         }
-      }
-      elemNodeMapBC_.insert({face, faceNodes});
-
-      for (auto faceNode : faceNodes) {
-        nodeElemMapBC_.insert({faceNode, {face}});
       }
     }
   }
@@ -787,11 +764,8 @@ PromoteElement::make_base_nodes_to_elem_map_at_boundary(
    * generates a map between a (sorted) vector of the element's
    * node ids to the element itself
    */
-
-  auto rank = (dimension_ == 2) ?
-      stk::topology::EDGE_RANK : stk::topology::FACE_RANK;
   const auto& baseElemSideBuckets = mesh.get_buckets(
-    rank,
+    mesh.mesh_meta_data().side_rank(),
     stk::mesh::selectUnion(mesh_parts)
   );
 
@@ -812,31 +786,33 @@ PromoteElement::make_base_nodes_to_elem_map_at_boundary(
         parents[j] = mesh.identifier(node_rels[j]);
       }
       std::sort(parents.begin(), parents.end());
-      nodesToElemMap.insert({parents,parent_elem});
+      nodesToElemMap.insert({parents, parent_elem});
     }
   }
   return nodesToElemMap;
 }
 //--------------------------------------------------------------------------
-void
-PromoteElement::populate_exposed_face_to_super_elem_map(
+PromoteElement::ExposedFaceElemMap
+PromoteElement::make_exposed_face_to_super_elem_map(
   const ElementDescription& elemDesc,
   const stk::mesh::BulkData& mesh,
-  const stk::mesh::PartVector& mesh_parts,
-  const stk::mesh::PartVector& superElemParts)
+  const stk::mesh::PartVector& base_elem_mesh_parts) const
 {
-  /* Generates a map between each exposed face and the super-element
+  /*
+   * Generates a map between each exposed face and the super-element
    * notionally attached to that exposed face.
    */
 
+  ThrowAssert(part_vector_is_valid(super_elem_part_vector(base_elem_mesh_parts)));
   const auto& superElemBuckets = mesh.get_buckets(
     stk::topology::ELEM_RANK,
-    stk::mesh::selectUnion(superElemParts)
+    stk::mesh::selectUnion(super_elem_part_vector(base_elem_mesh_parts))
   );
   auto nodesToElemMap =
-      make_base_nodes_to_elem_map_at_boundary(elemDescription_, mesh, mesh_parts);
+      make_base_nodes_to_elem_map_at_boundary(elemDesc, mesh, base_elem_mesh_parts);
 
   std::unordered_map<stk::mesh::Entity, stk::mesh::Entity> elemToSuperElemMap;
+  elemToSuperElemMap.reserve(nodesToElemMap.size());
 
   const auto baseNumNodes = elemDesc.nodesInBaseElement;
   std::vector<stk::mesh::EntityId> parents(baseNumNodes);
@@ -845,7 +821,7 @@ PromoteElement::populate_exposed_face_to_super_elem_map(
     parents.resize(elemDesc.nodesInBaseElement);
     for (size_t k = 0; k < b.size(); ++k) {
       const auto* node_rels = b.begin_nodes(k);
-      ThrowAssert(b.num_nodes(k) > baseNumNodes);
+      ThrowAssert(b.num_nodes(k) > baseNumNodes || elemDesc.polyOrder == 1);
 
       // Requires the convention that the base nodes are stored
       // first in the elem node relations still holds
@@ -856,22 +832,22 @@ PromoteElement::populate_exposed_face_to_super_elem_map(
 
       auto it = nodesToElemMap.find(parents);
       if (it != nodesToElemMap.end()) {
-        const stk::mesh::Entity face = it->second;
+        const stk::mesh::Entity baseElem = it->second;
         const stk::mesh::Entity superElem = b[k];
-        elemToSuperElemMap.insert({face,superElem});
+        auto result = elemToSuperElemMap.insert({baseElem,superElem});
+        ThrowRequireMsg(result.second,
+          "Multiple superElems with same parent nodes as the base elements found");
       }
     }
   }
   nodesToElemMap.clear();
 
-  auto rank = (dimension_ == 2) ? stk::topology::EDGE_RANK : stk::topology::FACE_RANK;
-
   const stk::mesh::BucketVector& boundary_buckets = mesh.get_buckets(
-    rank, stk::mesh::selectUnion(mesh_parts)
+    mesh.mesh_meta_data().side_rank(), stk::mesh::selectUnion(base_elem_mesh_parts)
   );
 
-  auto nodes1D = elemDescription_.nodes1D;
-  std::vector<stk::mesh::Entity> faceNodes(std::pow(nodes1D,dimension_-1));
+  ExposedFaceElemMap exposedFaceToSuperElemMap;
+  exposedFaceToSuperElemMap.reserve(elemToSuperElemMap.size());
   for (const auto* ib : boundary_buckets) {
     const stk::mesh::Bucket& b = *ib;
     const stk::mesh::Bucket::size_type length = b.size();
@@ -881,9 +857,14 @@ PromoteElement::populate_exposed_face_to_super_elem_map(
       ThrowAssert(mesh.num_elements(face) == 1);
       const stk::mesh::Entity baseElem = mesh.begin_elements(face)[0];
       const stk::mesh::Entity superElem = elemToSuperElemMap.at(baseElem);
-      exposedFaceToSuperElemMap_.insert({face,{superElem}});
+      auto result = exposedFaceToSuperElemMap.insert({face,superElem});
+      ThrowRequireMsg(result.second,
+        "Multiple super elements associated with the same face");
+
     }
   }
+
+  return exposedFaceToSuperElemMap;
 }
 //==========================================================================
 // Class Definition
@@ -902,17 +883,15 @@ PromoteElement::ChildNodeRequest::ChildNodeRequest(
 void
 PromoteElement::ChildNodeRequest::set_node_entity_for_request(
   stk::mesh::BulkData& mesh,
-  const stk::mesh::PartVector& meshPartsForChildNodes) const
+  stk::mesh::Part& rootPart) const
 {
   // Creates the actual stk nodes on the parts indicated by
-  // "meshPartsForChildNodes" and also sets their node sharing relations
-
   for (unsigned j = 0; j < children_.size(); ++j) {
     auto& idProcPairs = procGIdPairsFromAllProcs_[j];
     std::sort(idProcPairs.begin(), idProcPairs.end());
 
     children_[j] = mesh.declare_entity(
-      stk::topology::NODE_RANK, get_id_for_child(j), meshPartsForChildNodes
+      stk::topology::NODE_RANK, get_id_for_child(j), rootPart
     );
 
     for (auto& idProcPair : idProcPairs) {
@@ -921,42 +900,6 @@ PromoteElement::ChildNodeRequest::set_node_entity_for_request(
       }
     }
   }
-}
-//--------------------------------------------------------------------------
-stk::mesh::PartVector
-PromoteElement::ChildNodeRequest::mesh_parts_for_child_nodes(
-  const stk::mesh::BulkData& mesh,
-  stk::mesh::PartVector parts) const
-{
-  // Determines the parts to place the child node on.
-  // Child nodes are placed on whichever parts from the "parts" input are shared between the
-  // parent nodes.
-
-  //FIXME(rcknaus): nodes can get assigned to the wrong part in the event of a "keyhole" element
-  // block
-  ThrowAssert(!parts.empty());
-  std::sort(parts.begin(), parts.end());
-
-  // Iteratively remove parts that are not shared by the parent nodes
-  for (unsigned i = 0; i < parentIds_.size(); ++i) {
-    auto parentNode = mesh.get_entity(stk::topology::NODE_RANK, parentIds_[i]);
-    stk::mesh::PartVector otherParts = mesh.bucket(parentNode).supersets();
-    std::sort(otherParts.begin(), otherParts.end());
-
-    stk::mesh::PartVector temp;
-    std::set_intersection(
-      parts.begin(), parts.end(),
-      otherParts.begin(), otherParts.end(),
-      std::back_inserter(temp)
-    );
-    parts = std::move(temp);
-  }
-
-  // get the promoted parts associated with the shared base parts, e.g.
-  // if part_1 and part 2 is shared between all parent nodes, return
-  // part_1_promoted and part_2_promoted
-  transform_to_promoted_part_vector(parts);
-  return parts;
 }
 //--------------------------------------------------------------------------
 void

--- a/src/element_promotion/PromotedPartHelper.C
+++ b/src/element_promotion/PromotedPartHelper.C
@@ -5,10 +5,13 @@
 /*  directory structure                                                   */
 /*------------------------------------------------------------------------*/
 #include <element_promotion/PromotedPartHelper.h>
+#include <NaluEnv.h>
 
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>
 #include <stk_util/environment/ReportHandler.hpp>
+#include <stk_topology/topology.hpp>
+
 
 #include <algorithm>
 #include <vector>
@@ -18,43 +21,101 @@ namespace sierra{
 namespace nalu{
 
   // A set of functions to deal with part pairs having specific ending tags
-
   bool part_vector_is_valid(const stk::mesh::PartVector& parts) {
     return (std::find(parts.begin(), parts.end(), nullptr) == parts.end() && !parts.empty() );
   }
   //--------------------------------------------------------------------------
-  std::string promotion_suffix()
+  bool check_part_topo(const stk::mesh::Part& part) {
+    const int dim = part.mesh_meta_data().spatial_dimension();
+    bool is_valid_elem_rank = false;
+    const stk::topology topo = part.topology();
+    if (topo.rank() == stk::topology::ELEM_RANK) {
+      is_valid_elem_rank = (dim == 2) ? topo == stk::topology::QUAD_4_2D : topo == stk::topology::HEX_8;
+    }
+
+    bool is_valid_side_rank = false;
+    if (topo.rank() == part.mesh_meta_data().side_rank()) {
+      is_valid_side_rank = (dim == 2) ? topo == stk::topology::LINE_2 : topo == stk::topology::QUAD_4;
+    }
+
+    if (!(is_valid_side_rank || is_valid_elem_rank)) {
+      NaluEnv::self().naluOutputP0()
+                  << "Part "  << part.name()
+                  << " has an invalid topology for promotion, " << topo.name()
+                  << "---only pure Hex/Quad meshes are currently supported." << std::endl;
+
+      return false;
+    }
+    return true;
+  }
+  //--------------------------------------------------------------------------
+  bool check_parts_for_promotion(const stk::mesh::PartVector& parts)
   {
-    return "_promoted";
+    for (const auto* ip : parts) {
+      ThrowRequireMsg(ip != nullptr, "An invalid part was designated for promotion.");
+      const stk::mesh::Part& part = *ip;
+      if (part.subsets().empty()) {
+        if (!check_part_topo(part)) {
+          return false;
+        }
+      }
+      else {
+        for (const auto* is : part.subsets()) {
+          ThrowRequireMsg(is != nullptr, "An invalid subset part was designated for promotion.");
+          const stk::mesh::Part& subsetPart = *is;
+          if (!check_part_topo(subsetPart)) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
   }
   //--------------------------------------------------------------------------
   std::string super_element_suffix()
   {
-    return "_se";
+    return "se";
   }
   //--------------------------------------------------------------------------
-  std::string promote_part_name(const std::string& base_name)
-  {
-    ThrowAssertMsg(!base_name.empty(), "Empty base name for promoted part");
-    return (base_name+promotion_suffix());
-  }
-  //--------------------------------------------------------------------------
-  std::string super_element_part_name(const std::string& base_name)
+  std::string super_element_part_name(std::string base_name)
   {
     ThrowAssertMsg(!base_name.empty(), "Empty base name for super elem part");
-    return (base_name+super_element_suffix());
+    return (base_name + super_element_suffix());
   }
   //--------------------------------------------------------------------------
-  std::string base_element_part_name(const std::string& super_name)
+  std::string super_subset_part_name(const std::string& base_name, int numElemNodes, int numSideNodes)
+  {
+    // subsetted part name.  Goes like "surfacese_super512_superside64_1"
+    // Ioss doesn't recognize "superside" but does recognize the "super" tag
+
+    // Note: there's a 32 character limit on the maximum length of the
+    // part name (Ioss throws a warning message), so economy on characters is good
+
+    ThrowAssertMsg(!base_name.empty(), "Empty base name for super elem part");
+    auto first_token = base_name.substr(0, base_name.find_first_of('_'));
+    auto last_token = base_name.substr(base_name.find_last_of("_"),base_name.length());
+    std::string name = first_token + super_element_suffix()
+        + "_super"  + std::to_string(numElemNodes)
+        + "_superside" + std::to_string(numSideNodes)
+        + last_token;
+
+    return name;
+  }
+  //--------------------------------------------------------------------------
+  std::string base_element_part_name(std::string super_name)
   {
     ThrowRequireMsg(super_name.find(super_element_suffix()) != std::string::npos,
       "Not a super-element part name!");
-    return (super_name.substr(0,super_name.length()-super_element_suffix().length()));
+    return (super_name.erase(super_name.find(super_element_suffix()),super_element_suffix().length()));
   }
   //--------------------------------------------------------------------------
   stk::mesh::Part* super_elem_part(const stk::mesh::Part& part)
   {
     return (part.mesh_meta_data().get_part(super_element_part_name(part.name())));
+  }
+  stk::mesh::Part* super_subset_part(const stk::mesh::Part& part, int numElemNodes, int numSideNodes)
+  {
+    return (part.mesh_meta_data().get_part(super_subset_part_name(part.name(), numElemNodes, numSideNodes)));
   }
   //--------------------------------------------------------------------------
   stk::mesh::Part* base_elem_part_from_super_elem_part(const stk::mesh::Part& super_elem_part)
@@ -68,25 +129,6 @@ namespace nalu{
     return (part->mesh_meta_data().get_part(super_element_part_name(part->name())));
   }
   //--------------------------------------------------------------------------
-  stk::mesh::Part* promoted_part(const stk::mesh::Part& part)
-  {
-    return (part.mesh_meta_data().get_part(promote_part_name(part.name())));
-  }
-  //--------------------------------------------------------------------------
-  stk::mesh::Part* promoted_part(const stk::mesh::Part* part)
-  {
-    ThrowAssert(part != nullptr);
-    return (part->mesh_meta_data().get_part(promote_part_name(part->name())));
-  }
-  //--------------------------------------------------------------------------
-  void transform_to_promoted_part_vector(stk::mesh::PartVector& parts)
-  {
-    ThrowAssert(part_vector_is_valid(parts));
-    std::transform(parts.begin(), parts.end(), parts.begin(), [](stk::mesh::Part* part) {
-      return promoted_part(part);
-    });
-  }
-  //--------------------------------------------------------------------------
   void transform_to_super_elem_part_vector(stk::mesh::PartVector& parts)
   {
     ThrowAssert(part_vector_is_valid(parts));
@@ -94,21 +136,52 @@ namespace nalu{
       return super_elem_part(part);
     });
   }
-  //--------------------------------------------------------------------------
-  stk::mesh::PartVector promote_part_vector(stk::mesh::PartVector parts)
+  //------------------------------------------------------------------------
+  bool is_super(const stk::mesh::Part* p) {
+    return (p->topology().is_superedge()
+         || p->topology().is_superface()
+         || p->topology().is_superelement());
+  }
+  //------------------------------------------------------------------------
+  bool is_side(const stk::mesh::Part* p) {
+    return (p->mesh_meta_data().side_rank() == p->topology().side_rank());
+  }
+  //------------------------------------------------------------------------
+  bool is_super_side(const stk::mesh::Part* p) {
+    return (is_super(p) && is_side(p));
+  }
+   //------------------------------------------------------------------------
+  stk::mesh::PartVector base_ranked_parts(const stk::mesh::PartVector& parts, stk::topology::rank_t rank)
   {
-    transform_to_promoted_part_vector(parts);
-    return parts;
+    ThrowAssert(part_vector_is_valid(parts));
+
+    stk::mesh::PartVector elemParts;
+    std::copy_if(parts.begin(), parts.end(), std::back_inserter(elemParts), [rank](stk::mesh::Part* p) {
+      return (p->topology().rank() == rank && !is_super(p));
+    });
+    return elemParts;
   }
   //--------------------------------------------------------------------------
   stk::mesh::PartVector base_elem_parts(const stk::mesh::PartVector& parts)
+  {
+    return base_ranked_parts(parts, stk::topology::ELEM_RANK);
+  }
+  //--------------------------------------------------------------------------
+  stk::mesh::PartVector only_super_parts(const stk::mesh::PartVector& parts)
   {
     ThrowAssert(part_vector_is_valid(parts));
 
     stk::mesh::PartVector elemParts;
     std::copy_if(parts.begin(), parts.end(), std::back_inserter(elemParts), [](stk::mesh::Part* p) {
-      return (p->topology().rank() == stk::topology::ELEM_RANK
-           && p->topology() < stk::topology::SUPERELEMENT_START);
+      if (is_super(p)) {
+        return true;
+      }
+      for (const auto* subset : p->subsets()) {
+        if (is_super(subset)) {
+          return true;
+        }
+      }
+      return false;
     });
     return elemParts;
   }
@@ -119,9 +192,28 @@ namespace nalu{
 
     stk::mesh::PartVector elemParts;
     std::copy_if(parts.begin(), parts.end(), std::back_inserter(elemParts), [](stk::mesh::Part* p) {
-      return (p->topology() >= stk::topology::SUPERELEMENT_START);
+      return (p->topology().is_superelement());
     });
     return elemParts;
+  }
+  //--------------------------------------------------------------------------
+  stk::mesh::PartVector only_super_side_parts(const stk::mesh::PartVector& parts)
+  {
+    ThrowAssert(part_vector_is_valid(parts));
+
+    stk::mesh::PartVector faceParts;
+    std::copy_if(parts.begin(), parts.end(), std::back_inserter(faceParts), [](stk::mesh::Part* p) {
+      if (is_super(p) && is_side(p)) {
+        return true;
+      }
+      for (const auto* subset : p->subsets()) {
+        if (is_super(subset) && is_side(subset)) {
+          return true;
+        }
+      }
+      return false;
+    });
+    return faceParts;
   }
   //--------------------------------------------------------------------------
   stk::mesh::PartVector super_elem_part_vector(const stk::mesh::PartVector& parts)
@@ -131,29 +223,22 @@ namespace nalu{
     return baseElemParts;
   }
   //--------------------------------------------------------------------------
-  stk::mesh::PartVector append_super_elems_to_part_vector(stk::mesh::PartVector parts)
-  {
-    auto superElemParts = super_elem_part_vector(parts);
-    parts.insert(parts.end(), superElemParts.begin(), superElemParts.end());
-    return parts;
-  }
-  //--------------------------------------------------------------------------
   size_t
   num_sub_elements(
-    const stk::mesh::MetaData& metaData,
+    const int dim,
     const stk::mesh::BucketVector& buckets,
     unsigned polyOrder)
   {
+    ThrowRequire(dim == 2 || dim == 3);
+    int faceSize = std::pow(polyOrder,dim-1);
+    int elemSize = std::pow(polyOrder,dim);
+    auto side_rank = (dim == 2) ? stk::topology::EDGE_RANK : stk::topology::FACE_RANK;
     unsigned numEntities = 0;
     for (const auto* ib : buckets) {
-      unsigned subElemsPerElem =
-          (ib->topology().rank() == metaData.side_rank()) ?
-              std::pow(polyOrder, metaData.spatial_dimension() - 1) :
-              std::pow(polyOrder, metaData.spatial_dimension());
-
+      unsigned subElemsPerElem = (ib->topology().rank() == side_rank) ? faceSize : elemSize;
       numEntities += ib->size()*subElemsPerElem;
     }
-    return (numEntities);
+    return numEntities;
   }
   //--------------------------------------------------------------------------
   size_t

--- a/src/element_promotion/TensorProductQuadratureRule.C
+++ b/src/element_promotion/TensorProductQuadratureRule.C
@@ -43,7 +43,7 @@ TensorProductQuadratureRule::TensorProductQuadratureRule(
     }
     useSGL_ = false;
   }
-  else if (type == "SGL"){
+  else if (type == "SGL") {
     int numNodes = scsLocs.size()+1;
     numQuad_ = 1; // only 1 quadrature point per scv
     std::tie(abscissae_, weights_) = SGL_quadrature_rule(numNodes, scsEndLoc_);

--- a/src/mesh_motion/AssemblePressureForceBCSolverAlgorithm.C
+++ b/src/mesh_motion/AssemblePressureForceBCSolverAlgorithm.C
@@ -110,7 +110,7 @@ AssemblePressureForceBCSolverAlgorithm::execute()
     // face master element
     MasterElement *meFC = realm_.get_surface_master_element(b.topology());
     const int nodesPerFace = meFC->nodesPerElement_;
-    std::vector<int> face_node_ordinal_vec(nodesPerFace);
+
 
     // resize some things; matrix related
     const int lhsSize = nodesPerElement*nDim*nodesPerElement*nDim;
@@ -159,7 +159,7 @@ AssemblePressureForceBCSolverAlgorithm::execute()
       // gather nodal data off of face
       //======================================
       stk::mesh::Entity const * face_node_rels = bulk_data .begin_nodes(face);
-      int num_face_nodes = realm_.num_side_nodes_all(face);
+      int num_face_nodes = bulk_data.num_nodes(face);
       // sanity check on num nodes
       ThrowAssert( num_face_nodes == nodesPerFace );
       for ( int ni = 0; ni < num_face_nodes; ++ni ) {
@@ -176,13 +176,13 @@ AssemblePressureForceBCSolverAlgorithm::execute()
       }
 
       // extract the connected element to this exposed face; should be single in size!
-      const stk::mesh::Entity* face_elem_rels = realm_.face_elem_map(face);
+      const stk::mesh::Entity* face_elem_rels = bulk_data.begin_elements(face);
       ThrowAssert( bulk_data.num_elements(face) == 1 );
 
-      // get element; its face ordinal number and populate face_node_ordinal_vec
+      // get element; its face ordinal number and populate face_node_ordinals
       stk::mesh::Entity element = face_elem_rels[0];
       const int face_ordinal = bulk_data.begin_element_ordinals(face)[0];
-      realm_.side_node_ordinals_all(theElemTopo,face_ordinal,face_node_ordinal_vec);
+      const int *face_node_ordinals = meSCS->side_node_ordinals(face_ordinal);
 
       //==========================================
       // gather nodal data off of element; n/a
@@ -203,7 +203,7 @@ AssemblePressureForceBCSolverAlgorithm::execute()
       // loop over face nodes
       for ( int ip = 0; ip < num_face_nodes; ++ip ) {
 
-        const int nearestNode = face_node_ordinal_vec[ip];
+        const int nearestNode = face_node_ordinals[ip];
 
         const int offSetSF_face = ip*nodesPerFace;
 

--- a/src/overset/OversetInfo.C
+++ b/src/overset/OversetInfo.C
@@ -43,5 +43,5 @@ OversetInfo::~OversetInfo()
   // nothing to delete
 }
 
-} // namespace NaluUnit
+} // namespace nalu
 } // namespace sierra

--- a/src/overset/OversetManager.C
+++ b/src/overset/OversetManager.C
@@ -957,5 +957,5 @@ OversetManager::complete_search(
   }  
 }
 
-} // namespace naluUnit
+} // namespace nalu
 } // namespace Sierra

--- a/src/pmr/AssembleRadTransWallSolverAlgorithm.C
+++ b/src/pmr/AssembleRadTransWallSolverAlgorithm.C
@@ -69,6 +69,7 @@ void
 AssembleRadTransWallSolverAlgorithm::execute()
 {
 
+  stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
@@ -150,7 +151,7 @@ AssembleRadTransWallSolverAlgorithm::execute()
       //======================================
       // gather nodal data off of face
       //======================================
-      stk::mesh::Entity const * face_node_rels = realm_.begin_side_nodes_all(face);
+      stk::mesh::Entity const * face_node_rels = bulk_data.begin_nodes(face);
       for ( int ni = 0; ni < nodesPerFace; ++ni ) {
         stk::mesh::Entity node = face_node_rels[ni];
         connected_nodes[ni] = node;

--- a/src/user_functions/SteadyTaylorVortexContinuitySrcElemSuppAlg.C
+++ b/src/user_functions/SteadyTaylorVortexContinuitySrcElemSuppAlg.C
@@ -105,8 +105,8 @@ SteadyTaylorVortexContinuitySrcElemSuppAlg::elem_execute(
   const int numScvIp = meSCV->numIntPoints_;
   
   // gather
-  stk::mesh::Entity const *  node_rels =  bulkData_->begin_nodes(element);
-  int num_nodes =  bulkData_->num_nodes(element);
+  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
+  int num_nodes = bulkData_->num_nodes(element);
   
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );

--- a/src/user_functions/VariableDensityContinuitySrcElemSuppAlg.C
+++ b/src/user_functions/VariableDensityContinuitySrcElemSuppAlg.C
@@ -6,7 +6,7 @@
 /*------------------------------------------------------------------------*/
 
 
-#include <MomentumMassBackwardEulerElemSuppAlg.h>
+#include <user_functions/VariableDensityContinuitySrcElemSuppAlg.h>
 #include <SupplementalAlgorithm.h>
 #include <FieldTypeDef.h>
 #include <Realm.h>
@@ -24,60 +24,48 @@ namespace nalu{
 //==========================================================================
 // Class Definition
 //==========================================================================
-// MomentumMassBackwardEulerElemSuppAlg - base class for algorithm
+// VariableDensityContinuitySrcElemSuppAlg - base class for algorithm
 //==========================================================================
 //--------------------------------------------------------------------------
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
-MomentumMassBackwardEulerElemSuppAlg::MomentumMassBackwardEulerElemSuppAlg(
+VariableDensityContinuitySrcElemSuppAlg::VariableDensityContinuitySrcElemSuppAlg(
   Realm &realm)
   : SupplementalAlgorithm(realm),
     bulkData_(&realm.bulk_data()),
-    velocityN_(NULL),
-    velocityNp1_(NULL),
-    densityN_(NULL),
-    densityNp1_(NULL),
-    Gjp_(NULL),
     coordinates_(NULL),
-    dt_(0.0),
     nDim_(realm_.spatialDimension_),
+    unot_(1.0),
+    vnot_(1.0),
+    wnot_(1.0),
+    znot_(1.0),
+    rhoP_(0.1),
+    rhoS_(1.0),
+    a_(20.0),
+    amf_(10.0),
+    pi_(std::acos(-1.0)),
+    projTimeScale_(1.0),
     useShifted_(false)
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
-  VectorFieldType *velocity = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  velocityN_ = &(velocity->field_of_state(stk::mesh::StateN));
-  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  densityN_ = &(density->field_of_state(stk::mesh::StateN));
-  densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  Gjp_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
   coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
 
   // scratch vecs
-  uNScv_.resize(nDim_);
-  uNp1Scv_.resize(nDim_);
-  GjpScv_.resize(nDim_);
+  scvCoords_.resize(nDim_);
 }
 
 //--------------------------------------------------------------------------
 //-------- elem_resize -----------------------------------------------------
 //--------------------------------------------------------------------------
 void
-MomentumMassBackwardEulerElemSuppAlg::elem_resize(
+VariableDensityContinuitySrcElemSuppAlg::elem_resize(
   MasterElement */*meSCS*/,
   MasterElement *meSCV)
 {
   const int nodesPerElement = meSCV->nodesPerElement_;
   const int numScvIp = meSCV->numIntPoints_;
-
-  // resize
   ws_shape_function_.resize(numScvIp*nodesPerElement);
-  ws_uN_.resize(nDim_*nodesPerElement);
-  ws_uNp1_.resize(nDim_*nodesPerElement);
-  ws_Gjp_.resize(nDim_*nodesPerElement);
-  ws_rhoN_.resize(nodesPerElement);
-  ws_rhoNp1_.resize(nodesPerElement);
   ws_coordinates_.resize(nDim_*nodesPerElement);
   ws_scv_volume_.resize(numScvIp);
 
@@ -92,17 +80,17 @@ MomentumMassBackwardEulerElemSuppAlg::elem_resize(
 //-------- setup -----------------------------------------------------------
 //--------------------------------------------------------------------------
 void
-MomentumMassBackwardEulerElemSuppAlg::setup()
+VariableDensityContinuitySrcElemSuppAlg::setup()
 {
-  dt_ = realm_.get_time_step();
+  projTimeScale_ = realm_.get_time_step()/realm_.get_gamma1();
 }
 
 //--------------------------------------------------------------------------
 //-------- elem_execute ----------------------------------------------------
 //--------------------------------------------------------------------------
 void
-MomentumMassBackwardEulerElemSuppAlg::elem_execute(
-  double *lhs,
+VariableDensityContinuitySrcElemSuppAlg::elem_execute(
+  double */*lhs*/,
   double *rhs,
   stk::mesh::Entity element,
   MasterElement */*meSCS*/,
@@ -112,32 +100,21 @@ MomentumMassBackwardEulerElemSuppAlg::elem_execute(
   const int *ipNodeMap = meSCV->ipNodeMap();
   const int nodesPerElement = meSCV->nodesPerElement_;
   const int numScvIp = meSCV->numIntPoints_;
-
+  
   // gather
   stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
   int num_nodes = bulkData_->num_nodes(element);
-
+  
   // sanity check on num nodes
   ThrowAssert( num_nodes == nodesPerElement );
-
+  
   for ( int ni = 0; ni < num_nodes; ++ni ) {
     stk::mesh::Entity node = node_rels[ni];
     // pointers to real data
-    const double * uN = stk::mesh::field_data(*velocityN_, node );
-    const double * uNp1 = stk::mesh::field_data(*velocityNp1_, node );
-    const double * Gjp = stk::mesh::field_data(*Gjp_, node );
-    const double * coords =  stk::mesh::field_data(*coordinates_, node);
-   
-    // gather scalars
-    ws_rhoN_[ni] = *stk::mesh::field_data(*densityN_, node);
-    ws_rhoNp1_[ni] = *stk::mesh::field_data(*densityNp1_, node);
-
+    const double * coords = stk::mesh::field_data(*coordinates_, node );
     // gather vectors
     const int niNdim = ni*nDim_;
     for ( int j=0; j < nDim_; ++j ) {
-      ws_uN_[niNdim+j] = uN[j];
-      ws_uNp1_[niNdim+j] = uNp1[j];
-      ws_Gjp_[niNdim+j] = Gjp[j];
       ws_coordinates_[niNdim+j] = coords[j];
     }
   }
@@ -145,65 +122,29 @@ MomentumMassBackwardEulerElemSuppAlg::elem_execute(
   // compute geometry
   double scv_error = 0.0;
   meSCV->determinant(1, &ws_coordinates_[0], &ws_scv_volume_[0], &scv_error);
-
+  
   for ( int ip = 0; ip < numScvIp; ++ip ) {
-      
+    
     // nearest node to ip
     const int nearestNode = ipNodeMap[ip];
     
-    // zero out; scalar and vector
-    double rhoNScv = 0.0;
-    double rhoNp1Scv = 0.0;
-    for ( int j =0; j < nDim_; ++j ) {
-      uNScv_[j] = 0.0;
-      uNp1Scv_[j] = 0.0;
-      GjpScv_[j] = 0.0;
-    }
-      
+    // zero out
+    for ( int j =0; j < nDim_; ++j )
+      scvCoords_[j] = 0.0;
+    
     const int offSet = ip*nodesPerElement;
     for ( int ic = 0; ic < nodesPerElement; ++ic ) {
-      // save off shape function
       const double r = ws_shape_function_[offSet+ic];
-
-      // density
-      rhoNScv += r*ws_rhoN_[ic];
-      rhoNp1Scv += r*ws_rhoNp1_[ic];
-
-      // velocity
-      const int icNdim = ic*nDim_;
-      for ( int j = 0; j < nDim_; ++j ) {
-        uNScv_[j] += r*ws_uN_[icNdim+j];
-        uNp1Scv_[j] += r*ws_uNp1_[icNdim+j];
-        GjpScv_[j] += r*ws_Gjp_[icNdim+j];
-      }
+      for ( int j = 0; j < nDim_; ++j )
+        scvCoords_[j] += r*ws_coordinates_[ic*nDim_+j];
     }
-
-    // assemble rhs
-    const double scV = ws_scv_volume_[ip];
-    const int nnNdim = nearestNode*nDim_;
-    for ( int i = 0; i < nDim_; ++i ) {
-      rhs[nnNdim+i] += 
-        -(rhoNp1Scv*uNp1Scv_[i]-rhoNScv*uNScv_[i])*scV/dt_
-        -GjpScv_[i]*scV; //- ws_Gjp_[nnNdim+i]*scV;
-    }
+    const double x = scvCoords_[0];
+    const double y = scvCoords_[1];
+    const double z = scvCoords_[2];
     
-    // manage LHS
-    for ( int ic = 0; ic < nodesPerElement; ++ic ) {
-      
-      const int icNdim = ic*nDim_;
-      
-      // save off shape function
-      const double r = ws_shape_function_[offSet+ic];
-      
-      const double lhsfac = r*rhoNp1Scv*scV/dt_;
-      
-      for ( int i = 0; i < nDim_; ++i ) {
-        const int indexNN = nnNdim + i;
-        const int rowNN = indexNN*nodesPerElement*nDim_;
-        const int rNNiC_i = rowNN+icNdim+i;
-        lhs[rNNiC_i] += lhsfac;
-      }
-    }   
+    const double src = 0.10e1 * pow(znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_, -0.2e1) * unot_ * cos(a_ * pi_ * x) * sin(a_ * pi_ * y) * sin(a_ * pi_ * z) * (-znot_ * sin(amf_ * pi_ * x) * amf_ * pi_ * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + znot_ * sin(amf_ * pi_ * x) * amf_ * pi_ * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoS_) + 0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * unot_ * sin(a_ * pi_ * x) * a_ * pi_ * sin(a_ * pi_ * y) * sin(a_ * pi_ * z) - 0.10e1 * pow(znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_, -0.2e1) * vnot_ * sin(a_ * pi_ * x) * cos(a_ * pi_ * y) * sin(a_ * pi_ * z) * (-znot_ * cos(amf_ * pi_ * x) * sin(amf_ * pi_ * y) * amf_ * pi_ * cos(amf_ * pi_ * z) / rhoP_ + znot_ * cos(amf_ * pi_ * x) * sin(amf_ * pi_ * y) * amf_ * pi_ * cos(amf_ * pi_ * z) / rhoS_) - 0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * vnot_ * sin(a_ * pi_ * x) * sin(a_ * pi_ * y) * a_ * pi_ * sin(a_ * pi_ * z) + 0.10e1 * pow(znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_, -0.2e1) * wnot_ * sin(a_ * pi_ * x) * sin(a_ * pi_ * y) * cos(a_ * pi_ * z) * (-znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * sin(amf_ * pi_ * z) * amf_ * pi_ / rhoP_ + znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * sin(amf_ * pi_ * z) * amf_ * pi_ / rhoS_) + 0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * wnot_ * sin(a_ * pi_ * x) * sin(a_ * pi_ * y) * sin(a_ * pi_ * z) * a_ * pi_;
+
+    rhs[nearestNode] += src*ws_scv_volume_[ip]/projTimeScale_;      
   }
 }
 

--- a/src/user_functions/VariableDensityMomentumSrcElemSuppAlg.C
+++ b/src/user_functions/VariableDensityMomentumSrcElemSuppAlg.C
@@ -1,0 +1,176 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include <user_functions/VariableDensityMomentumSrcElemSuppAlg.h>
+#include <SupplementalAlgorithm.h>
+#include <FieldTypeDef.h>
+#include <Realm.h>
+#include <SolutionOptions.h>
+#include <master_element/MasterElement.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// VariableDensityMomentumSrcElemSuppAlg - base class for algorithm
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+VariableDensityMomentumSrcElemSuppAlg::VariableDensityMomentumSrcElemSuppAlg(
+  Realm &realm)
+  : SupplementalAlgorithm(realm),
+    bulkData_(&realm.bulk_data()),
+    coordinates_(NULL),
+    nDim_(realm_.spatialDimension_),
+    unot_(1.0),
+    vnot_(1.0),
+    wnot_(1.0),
+    pnot_(1.0),
+    znot_(1.0),
+    a_(20.0),
+    amf_(10.0),
+    visc_(0.001),
+    rhoP_(0.1),
+    rhoS_(1.0),
+    pi_(std::acos(-1.0)),
+    twoThirds_(2.0/3.0*realm_.get_divU()),
+    rhoRef_(1.0),
+    gx_(0.0),
+    gy_(0.0),
+    gz_(0.0),
+    useShifted_(false)
+{
+  // save off fields
+  stk::mesh::MetaData & meta_data = realm_.meta_data();
+  coordinates_ = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, realm_.get_coordinates_name());
+ 
+  // scratch vecs
+  scvCoords_.resize(nDim_);
+  srcXi_.resize(nDim_);
+
+  // extract user parameters from solution options
+  std::vector<double> gravity = realm_.solutionOptions_->gravity_;
+  rhoRef_ = realm_.solutionOptions_->referenceDensity_;
+  gx_ = gravity[0];
+  gy_ = gravity[1];
+  gz_ = gravity[2];
+}
+
+//--------------------------------------------------------------------------
+//-------- elem_resize -----------------------------------------------------
+//--------------------------------------------------------------------------
+void
+VariableDensityMomentumSrcElemSuppAlg::elem_resize(
+  MasterElement */*meSCS*/,
+  MasterElement *meSCV)
+{
+  const int nodesPerElement = meSCV->nodesPerElement_;
+  const int numScvIp = meSCV->numIntPoints_;
+  ws_shape_function_.resize(numScvIp*nodesPerElement);
+  ws_coordinates_.resize(nDim_*nodesPerElement);
+  ws_scv_volume_.resize(numScvIp);
+
+  // compute shape function
+  if ( useShifted_ )
+    meSCV->shifted_shape_fcn(&ws_shape_function_[0]);
+  else
+    meSCV->shape_fcn(&ws_shape_function_[0]);
+}
+
+//--------------------------------------------------------------------------
+//-------- setup -----------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+VariableDensityMomentumSrcElemSuppAlg::setup()
+{
+  // nothing
+}
+
+//--------------------------------------------------------------------------
+//-------- elem_execute ----------------------------------------------------
+//--------------------------------------------------------------------------
+void
+VariableDensityMomentumSrcElemSuppAlg::elem_execute(
+  double */*lhs*/,
+  double *rhs,
+  stk::mesh::Entity element,
+  MasterElement */*meSCS*/,
+  MasterElement *meSCV)
+{
+  // pointer to ME methods
+  const int *ipNodeMap = meSCV->ipNodeMap();
+  const int nodesPerElement = meSCV->nodesPerElement_;
+  const int numScvIp = meSCV->numIntPoints_;
+  
+  // gather
+  stk::mesh::Entity const *  node_rels = bulkData_->begin_nodes(element);
+  int num_nodes = bulkData_->num_nodes(element);
+  
+  // sanity check on num nodes
+  ThrowAssert( num_nodes == nodesPerElement );
+  
+  for ( int ni = 0; ni < num_nodes; ++ni ) {
+    stk::mesh::Entity node = node_rels[ni];
+    // pointers to real data
+    const double * coords = stk::mesh::field_data(*coordinates_, node );
+    // gather vectors
+    const int niNdim = ni*nDim_;
+    for ( int j=0; j < nDim_; ++j ) {
+      ws_coordinates_[niNdim+j] = coords[j];
+    }
+  }
+  
+  // compute geometry
+  double scv_error = 0.0;
+  meSCV->determinant(1, &ws_coordinates_[0], &ws_scv_volume_[0], &scv_error);
+  
+  for ( int ip = 0; ip < numScvIp; ++ip ) {
+    
+    // nearest node to ip
+    const int nearestNode = ipNodeMap[ip];
+    
+    // zero out
+    for ( int j =0; j < nDim_; ++j )
+      scvCoords_[j] = 0.0;
+    
+    const int offSet = ip*nodesPerElement;
+    for ( int ic = 0; ic < nodesPerElement; ++ic ) {
+      const double r = ws_shape_function_[offSet+ic];
+      for ( int j = 0; j < nDim_; ++j )
+        scvCoords_[j] += r*ws_coordinates_[ic*nDim_+j];
+    }
+
+    const double x = scvCoords_[0];
+    const double y = scvCoords_[1];  
+    const double z = scvCoords_[2];
+
+    srcXi_[0] = -0.10e1 * pow(znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_, -0.2e1) * unot_ * unot_ * pow(cos(a_ * pi_ * x), 0.2e1) * pow(sin(a_ * pi_ * y), 0.2e1) * pow(sin(a_ * pi_ * z), 0.2e1) * (-znot_ * sin(amf_ * pi_ * x) * amf_ * pi_ * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + znot_ * sin(amf_ * pi_ * x) * amf_ * pi_ * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoS_) - 0.20e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * unot_ * unot_ * cos(a_ * pi_ * x) * pow(sin(a_ * pi_ * y), 0.2e1) * pow(sin(a_ * pi_ * z), 0.2e1) * sin(a_ * pi_ * x) * a_ * pi_ + 0.10e1 * pow(znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_, -0.2e1) * vnot_ * sin(a_ * pi_ * x) * cos(a_ * pi_ * y) * pow(sin(a_ * pi_ * z), 0.2e1) * unot_ * cos(a_ * pi_ * x) * sin(a_ * pi_ * y) * (-znot_ * cos(amf_ * pi_ * x) * sin(amf_ * pi_ * y) * amf_ * pi_ * cos(amf_ * pi_ * z) / rhoP_ + znot_ * cos(amf_ * pi_ * x) * sin(amf_ * pi_ * y) * amf_ * pi_ * cos(amf_ * pi_ * z) / rhoS_) + 0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * vnot_ * sin(a_ * pi_ * x) * pow(sin(a_ * pi_ * y), 0.2e1) * a_ * pi_ * pow(sin(a_ * pi_ * z), 0.2e1) * unot_ * cos(a_ * pi_ * x) - 0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * vnot_ * sin(a_ * pi_ * x) * pow(cos(a_ * pi_ * y), 0.2e1) * pow(sin(a_ * pi_ * z), 0.2e1) * unot_ * cos(a_ * pi_ * x) * a_ * pi_ - 0.10e1 * pow(znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_, -0.2e1) * wnot_ * sin(a_ * pi_ * x) * pow(sin(a_ * pi_ * y), 0.2e1) * cos(a_ * pi_ * z) * unot_ * cos(a_ * pi_ * x) * sin(a_ * pi_ * z) * (-znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * sin(amf_ * pi_ * z) * amf_ * pi_ / rhoP_ + znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * sin(amf_ * pi_ * z) * amf_ * pi_ / rhoS_) - 0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * wnot_ * sin(a_ * pi_ * x) * pow(sin(a_ * pi_ * y), 0.2e1) * pow(sin(a_ * pi_ * z), 0.2e1) * a_ * pi_ * unot_ * cos(a_ * pi_ * x) + 0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * wnot_ * sin(a_ * pi_ * x) * pow(sin(a_ * pi_ * y), 0.2e1) * pow(cos(a_ * pi_ * z), 0.2e1) * unot_ * cos(a_ * pi_ * x) * a_ * pi_ - visc_ * (-(unot_ * cos(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * y) * sin(a_ * pi_ * z) - vnot_ * cos(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * y) * sin(a_ * pi_ * z) + wnot_ * cos(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * y) * sin(a_ * pi_ * z)) * twoThirds_ + 0.2e1 * unot_ * cos(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * y) * sin(a_ * pi_ * z)) - visc_ * (unot_ * cos(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * y) * sin(a_ * pi_ * z) - vnot_ * cos(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * y) * sin(a_ * pi_ * z)) - visc_ * (unot_ * cos(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * y) * sin(a_ * pi_ * z) + wnot_ * cos(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * y) * sin(a_ * pi_ * z)) + 0.50e0 * pnot_ * sin(0.2e1 * a_ * pi_ * x) * a_ * pi_ - (0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) - rhoRef_) * gx_;
+
+    srcXi_[1] = 0.10e1 * pow(znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_, -0.2e1) * vnot_ * sin(a_ * pi_ * x) * cos(a_ * pi_ * y) * pow(sin(a_ * pi_ * z), 0.2e1) * unot_ * cos(a_ * pi_ * x) * sin(a_ * pi_ * y) * (-znot_ * sin(amf_ * pi_ * x) * amf_ * pi_ * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + znot_ * sin(amf_ * pi_ * x) * amf_ * pi_ * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoS_) - 0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * vnot_ * pow(cos(a_ * pi_ * x), 0.2e1) * a_ * pi_ * cos(a_ * pi_ * y) * pow(sin(a_ * pi_ * z), 0.2e1) * unot_ * sin(a_ * pi_ * y) + 0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * vnot_ * pow(sin(a_ * pi_ * x), 0.2e1) * cos(a_ * pi_ * y) * pow(sin(a_ * pi_ * z), 0.2e1) * unot_ * a_ * pi_ * sin(a_ * pi_ * y) - 0.10e1 * pow(znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_, -0.2e1) * vnot_ * vnot_ * pow(sin(a_ * pi_ * x), 0.2e1) * pow(cos(a_ * pi_ * y), 0.2e1) * pow(sin(a_ * pi_ * z), 0.2e1) * (-znot_ * cos(amf_ * pi_ * x) * sin(amf_ * pi_ * y) * amf_ * pi_ * cos(amf_ * pi_ * z) / rhoP_ + znot_ * cos(amf_ * pi_ * x) * sin(amf_ * pi_ * y) * amf_ * pi_ * cos(amf_ * pi_ * z) / rhoS_) - 0.20e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * vnot_ * vnot_ * pow(sin(a_ * pi_ * x), 0.2e1) * cos(a_ * pi_ * y) * pow(sin(a_ * pi_ * z), 0.2e1) * sin(a_ * pi_ * y) * a_ * pi_ + 0.10e1 * pow(znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_, -0.2e1) * wnot_ * pow(sin(a_ * pi_ * x), 0.2e1) * sin(a_ * pi_ * y) * cos(a_ * pi_ * z) * vnot_ * cos(a_ * pi_ * y) * sin(a_ * pi_ * z) * (-znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * sin(amf_ * pi_ * z) * amf_ * pi_ / rhoP_ + znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * sin(amf_ * pi_ * z) * amf_ * pi_ / rhoS_) + 0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * wnot_ * pow(sin(a_ * pi_ * x), 0.2e1) * sin(a_ * pi_ * y) * pow(sin(a_ * pi_ * z), 0.2e1) * a_ * pi_ * vnot_ * cos(a_ * pi_ * y) - 0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * wnot_ * pow(sin(a_ * pi_ * x), 0.2e1) * sin(a_ * pi_ * y) * pow(cos(a_ * pi_ * z), 0.2e1) * vnot_ * cos(a_ * pi_ * y) * a_ * pi_ - visc_ * (unot_ * sin(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * cos(a_ * pi_ * y) * sin(a_ * pi_ * z) - vnot_ * sin(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * cos(a_ * pi_ * y) * sin(a_ * pi_ * z)) - visc_ * (-(unot_ * sin(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * cos(a_ * pi_ * y) * sin(a_ * pi_ * z) - vnot_ * sin(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * cos(a_ * pi_ * y) * sin(a_ * pi_ * z) + wnot_ * sin(a_ * pi_ * x) * cos(a_ * pi_ * y) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * z)) * twoThirds_ - 0.2e1 * vnot_ * sin(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * cos(a_ * pi_ * y) * sin(a_ * pi_ * z)) - visc_ * (-vnot_ * sin(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * cos(a_ * pi_ * y) * sin(a_ * pi_ * z) + wnot_ * sin(a_ * pi_ * x) * cos(a_ * pi_ * y) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * z)) + 0.50e0 * pnot_ * sin(0.2e1 * a_ * pi_ * y) * a_ * pi_ - (0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) - rhoRef_) * gy_;
+
+    srcXi_[2] = -0.10e1 * pow(znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_, -0.2e1) * wnot_ * sin(a_ * pi_ * x) * pow(sin(a_ * pi_ * y), 0.2e1) * cos(a_ * pi_ * z) * unot_ * cos(a_ * pi_ * x) * sin(a_ * pi_ * z) * (-znot_ * sin(amf_ * pi_ * x) * amf_ * pi_ * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + znot_ * sin(amf_ * pi_ * x) * amf_ * pi_ * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoS_) + 0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * wnot_ * pow(cos(a_ * pi_ * x), 0.2e1) * a_ * pi_ * pow(sin(a_ * pi_ * y), 0.2e1) * cos(a_ * pi_ * z) * unot_ * sin(a_ * pi_ * z) - 0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * wnot_ * pow(sin(a_ * pi_ * x), 0.2e1) * pow(sin(a_ * pi_ * y), 0.2e1) * cos(a_ * pi_ * z) * unot_ * a_ * pi_ * sin(a_ * pi_ * z) + 0.10e1 * pow(znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_, -0.2e1) * wnot_ * pow(sin(a_ * pi_ * x), 0.2e1) * sin(a_ * pi_ * y) * cos(a_ * pi_ * z) * vnot_ * cos(a_ * pi_ * y) * sin(a_ * pi_ * z) * (-znot_ * cos(amf_ * pi_ * x) * sin(amf_ * pi_ * y) * amf_ * pi_ * cos(amf_ * pi_ * z) / rhoP_ + znot_ * cos(amf_ * pi_ * x) * sin(amf_ * pi_ * y) * amf_ * pi_ * cos(amf_ * pi_ * z) / rhoS_) - 0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * wnot_ * pow(sin(a_ * pi_ * x), 0.2e1) * pow(cos(a_ * pi_ * y), 0.2e1) * a_ * pi_ * cos(a_ * pi_ * z) * vnot_ * sin(a_ * pi_ * z) + 0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * wnot_ * pow(sin(a_ * pi_ * x), 0.2e1) * pow(sin(a_ * pi_ * y), 0.2e1) * cos(a_ * pi_ * z) * vnot_ * a_ * pi_ * sin(a_ * pi_ * z) - 0.10e1 * pow(znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_, -0.2e1) * wnot_ * wnot_ * pow(sin(a_ * pi_ * x), 0.2e1) * pow(sin(a_ * pi_ * y), 0.2e1) * pow(cos(a_ * pi_ * z), 0.2e1) * (-znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * sin(amf_ * pi_ * z) * amf_ * pi_ / rhoP_ + znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * sin(amf_ * pi_ * z) * amf_ * pi_ / rhoS_) - 0.20e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) * wnot_ * wnot_ * pow(sin(a_ * pi_ * x), 0.2e1) * pow(sin(a_ * pi_ * y), 0.2e1) * cos(a_ * pi_ * z) * sin(a_ * pi_ * z) * a_ * pi_ - visc_ * (unot_ * sin(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * y) * cos(a_ * pi_ * z) + wnot_ * sin(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * y) * cos(a_ * pi_ * z)) - visc_ * (-vnot_ * sin(a_ * pi_ * x) * sin(a_ * pi_ * y) * a_ * a_ * pi_ * pi_ * cos(a_ * pi_ * z) + wnot_ * sin(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * y) * cos(a_ * pi_ * z)) - visc_ * (-(unot_ * sin(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * y) * cos(a_ * pi_ * z) - vnot_ * sin(a_ * pi_ * x) * sin(a_ * pi_ * y) * a_ * a_ * pi_ * pi_ * cos(a_ * pi_ * z) + wnot_ * sin(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * y) * cos(a_ * pi_ * z)) * twoThirds_ + 0.2e1 * wnot_ * sin(a_ * pi_ * x) * a_ * a_ * pi_ * pi_ * sin(a_ * pi_ * y) * cos(a_ * pi_ * z)) + 0.50e0 * pnot_ * sin(0.2e1 * a_ * pi_ * z) * a_ * pi_ - (0.10e1 / (znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z) / rhoP_ + (0.1e1 - znot_ * cos(amf_ * pi_ * x) * cos(amf_ * pi_ * y) * cos(amf_ * pi_ * z)) / rhoS_) - rhoRef_) * gz_;
+
+    const double scV = ws_scv_volume_[ip];
+    const int nnNdim = nearestNode*nDim_;
+    for ( int i = 0; i < nDim_; ++i ) {
+      rhs[nnNdim+i] += srcXi_[i]*scV;      
+    }
+  }
+}
+
+} // namespace nalu
+} // namespace Sierra


### PR DESCRIPTION
* Sync with changes to master

* Uses super side-ranked parts at domain boundaries.  The "side_node_ordinals" call has been moved to Master Element, returning a pointer to the ordinals for a particular side instead of copying the ordinals into a vector.  All of the promotion logic is now done on part names rather than in the assembly.

* More things are working (due to super sides).  Periodic BCs and turbulence averaging now work properly.

* Added some additional checking for parts that aren't (currently) promote-able.

* Added an option to use a reduced (linear) basis for geometric calculations when the promoted element geometry remains linear.  Off by default: activate with " use_reduced_geometric_basis: yes" under the polynomial order specification.  Doesn't speed up calculations as much as I expected, but it is significant for high polynomial orders in 3D.

* Static condensation and the SGL quadrature assembly are still in progress.  The ElementCondenser class has a routine to compute the condensed elemental LHS/RHS given the full elemental LHS/RHS, as well another routine to compute the update to the interior dofs given the updated LHS/RHS.  The SGL quadrature is still only available for pure heat conduction, but it should be a little faster now (especially in 2D).

* Updated the estimate for linear system size in the case of high order.  Also added edge, face, and element ranked fields to the field size memory calculation.   Estimate for the higher order system will sometimes underpredict the total size.