### PR TITLE
Add a pprint flag to generate processor specific log files (Nalu issue #51)

### DIFF
--- a/include/NaluEnv.h
+++ b/include/NaluEnv.h
@@ -35,9 +35,11 @@ class NaluEnv
   int pRank_;
   std::ostream *naluLogStream_;
   std::ostream *naluParallelStream_;
+  bool parallelLog_;
   
   NaluEmptyStreamBuffer naluEmptyStreamBuffer_;
   std::filebuf naluStreamBuffer_;
+  std::filebuf naluParallelStreamBuffer_;
 
   std::ostream & naluOutputP0();
   std::ostream & naluOutput();
@@ -45,7 +47,7 @@ class NaluEnv
   MPI_Comm parallel_comm();
   int parallel_size();
   int parallel_rank();
-  void set_log_file_stream(std::string naluLogName);
+  void set_log_file_stream(std::string naluLogName, bool pprint = false);
   void close_log_file_stream();
   double nalu_time();
 };

--- a/include/NaluEnv.h
+++ b/include/NaluEnv.h
@@ -33,6 +33,7 @@ class NaluEnv
   MPI_Comm parallelCommunicator_;
   int pSize_;
   int pRank_;
+  std::streambuf *stdoutStream_;
   std::ostream *naluLogStream_;
   std::ostream *naluParallelStream_;
   bool parallelLog_;

--- a/nalu.C
+++ b/nalu.C
@@ -87,7 +87,8 @@ int main( int argc, char ** argv )
     ("serialized-io-group-size,s",
      boost::program_options::value<int>(&serializedIOGroupSize)->default_value(0),
         "Specifies the number of processors which can concurrently perform I/O. Specifying zero disables serialization.")
-    ("debug,D", "debug print on");
+    ("debug,D", "debug print on")
+    ("pprint,p", "parallel print on");
 
   boost::program_options::variables_map vm;
   boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), vm);
@@ -131,9 +132,13 @@ int main( int argc, char ** argv )
     }
   }
 
+  bool pprint = false;
+  if (vm.count("pprint")) {
+    pprint = true;
+  }
   // deal with log file stream
-  naluEnv.set_log_file_stream(logFileName);  
-  
+  naluEnv.set_log_file_stream(logFileName, pprint);
+
   // proceed with reading input file "document" from YAML
   YAML::Parser parser(fin);
   YAML::Node doc;

--- a/src/NaluEnv.C
+++ b/src/NaluEnv.C
@@ -29,7 +29,8 @@ NaluEnv::NaluEnv()
   : parallelCommunicator_(MPI_COMM_WORLD),
     pSize_(-1),
     pRank_(-1),
-    naluLogStream_(&std::cout),
+    stdoutStream_(std::cout.rdbuf()),
+    naluLogStream_(&std::cout), // std::cout redirects to log file
     naluParallelStream_(new std::ostream(&naluParallelStreamBuffer_)),
     parallelLog_(false)
 {
@@ -118,7 +119,7 @@ NaluEnv::set_log_file_stream(std::string naluLogName, bool pprint)
     naluParallelStream_->rdbuf(&naluParallelStreamBuffer_);
   }
   else {
-    naluParallelStream_->rdbuf(&naluEmptyStreamBuffer_);
+    naluParallelStream_->rdbuf(stdoutStream_);
   }
 }
 

--- a/src/Simulation.C
+++ b/src/Simulation.C
@@ -179,6 +179,23 @@ void Simulation::high_level_banner() {
   NaluEnv::self().naluOutputP0() << "-----------------------------------------------------------------" << std::endl;
   NaluEnv::self().naluOutputP0() << std::endl;
 
+
+  NaluEnv::self().naluOutput() << std::endl;
+  NaluEnv::self().naluOutput() << "=================================================================" << std::endl;
+  NaluEnv::self().naluOutput() << "                            Nalu:                                " << std::endl;
+  NaluEnv::self().naluOutput() << "      A low Mach number, turbulent reacting flow code with       " << std::endl;
+  NaluEnv::self().naluOutput() << "            coupling to PMR and object response (CHT)            " << std::endl;
+  NaluEnv::self().naluOutput() << "=================================================================" << std::endl;
+  NaluEnv::self().naluOutput() << std::endl;
+  NaluEnv::self().naluOutput() << "   TPLs: Boost, HDF5, netCDF, STK, Trilinos, YAML_cpp and zlib   " << std::endl;
+  NaluEnv::self().naluOutput() << std::endl;
+  NaluEnv::self().naluOutput() << "              Copyright 2014 Sandia Corporation.                 " << std::endl;
+  NaluEnv::self().naluOutput() << "      This software is released under the license detailed       " << std::endl;
+  NaluEnv::self().naluOutput() << "   in the file, LICENSE, which is located in the top-level Nalu  " << std::endl;
+  NaluEnv::self().naluOutput() << "                     directory structure                         " << std::endl;
+  NaluEnv::self().naluOutput() << "-----------------------------------------------------------------" << std::endl;
+  NaluEnv::self().naluOutput() << std::endl;
+
 }
 } // namespace nalu
 } // namespace Sierra

--- a/src/Simulation.C
+++ b/src/Simulation.C
@@ -179,23 +179,6 @@ void Simulation::high_level_banner() {
   NaluEnv::self().naluOutputP0() << "-----------------------------------------------------------------" << std::endl;
   NaluEnv::self().naluOutputP0() << std::endl;
 
-
-  NaluEnv::self().naluOutput() << std::endl;
-  NaluEnv::self().naluOutput() << "=================================================================" << std::endl;
-  NaluEnv::self().naluOutput() << "                            Nalu:                                " << std::endl;
-  NaluEnv::self().naluOutput() << "      A low Mach number, turbulent reacting flow code with       " << std::endl;
-  NaluEnv::self().naluOutput() << "            coupling to PMR and object response (CHT)            " << std::endl;
-  NaluEnv::self().naluOutput() << "=================================================================" << std::endl;
-  NaluEnv::self().naluOutput() << std::endl;
-  NaluEnv::self().naluOutput() << "   TPLs: Boost, HDF5, netCDF, STK, Trilinos, YAML_cpp and zlib   " << std::endl;
-  NaluEnv::self().naluOutput() << std::endl;
-  NaluEnv::self().naluOutput() << "              Copyright 2014 Sandia Corporation.                 " << std::endl;
-  NaluEnv::self().naluOutput() << "      This software is released under the license detailed       " << std::endl;
-  NaluEnv::self().naluOutput() << "   in the file, LICENSE, which is located in the top-level Nalu  " << std::endl;
-  NaluEnv::self().naluOutput() << "                     directory structure                         " << std::endl;
-  NaluEnv::self().naluOutput() << "-----------------------------------------------------------------" << std::endl;
-  NaluEnv::self().naluOutput() << std::endl;
-
 }
 } // namespace nalu
 } // namespace Sierra


### PR DESCRIPTION
Added a flag, "--pprint", to create processor-specific logfiles (e.g. nalu.0.log, nalu.1.log etc.).  naluOutput() directs to log file matching the processor rank its called on.  Currently, the processor-specific log files only contain the header from the log file. 